### PR TITLE
Add beep as a valid attribute for wait xml

### DIFF
--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -996,7 +996,7 @@ util.inherits(Speak, Response);
 
 function Wait(Response) {
     this.element = 'Wait';
-    this.valid_attributes = ['length', 'silence', 'min_silence', 'minSilence'];
+    this.valid_attributes = ['length', 'silence', 'min_silence', 'minSilence', 'beep'];
     this.nestables = [];
 }
 util.inherits(Wait, Response);


### PR DESCRIPTION
Can't add 'beep' attribute to a 'wait' XML element currently.

Trying to match documentation: https://www.plivo.com/docs/xml/wait/