### PR TITLE
Promise implementation

### DIFF
--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -38,9 +38,11 @@ var request = function (action, method, params, callback, optional) {
         }
     }
 
-    if (!callback) {
-        var callback = function() {};
-    }
+    var hasCallback = callback && callback instanceof Function;
+
+    // if (!callback) {
+    //     var callback = function() {};
+    // }
 
     var err = null;
     var path = 'https://' + plivo.options.host + '/' + plivo.options.version + '/Account/' + plivo.options.authId + '/' + action;
@@ -69,9 +71,22 @@ var request = function (action, method, params, callback, optional) {
           Request.post(request_options, function (error, response, body) {
               if (error || !response) {
                 //return callback(500, body)
-                reject( new PlivoError( error ) );
+                if ( hasCallback ) {
+                  callback( new PlivoError( error ) );
+                } else {
+                  reject( new PlivoError( error ) );
+                }
               } else {
-                resolve( response );
+                var success = {
+                  response: response,
+                  body: body
+                };
+
+                if ( hasCallback ) {
+                  callback( null, success );
+                } else {
+                  resolve( success );
+                }
               }
               // if (response.statusCode != 201) {
               //     err = new PlivoError(error);
@@ -84,20 +99,44 @@ var request = function (action, method, params, callback, optional) {
           request_options.qs = params;
           Request.get(request_options, function (error, response, body) {
               if ( error ) {
-                reject( new PlivoError( error ) );
+                if ( hasCallback ) {
+                  callback( new PlivoError( error ) );
+                } else {
+                  reject( new PlivoError( error ) );
+                }
               } else {
-                resolve( response );
+                var success = {
+                  response: response,
+                  body: body
+                };
+
+                if ( hasCallback ) {
+                  callback( null, success );
+                } else {
+                  resolve( success );
+                }
               }
-              //callback(response.statusCode, body);
           });
       } else if (method == 'DELETE') {
           Request.del(request_options, function (error, response, body) {
               if ( error ) {
-                reject( new PlivoError( error ) );
+                if ( hasCallback ) {
+                  callback( new PlivoError( error ) );
+                } else {
+                  reject( new PlivoError( error ) );
+                }
               } else {
-                resolve( response );
+                var success = {
+                  response: response,
+                  body: body
+                };
+
+                if ( hasCallback ) {
+                  callback( null, success );
+                } else {
+                  resolve( success );
+                }
               }
-              //callback(response.statusCode, body);
           });
       } else if (method == 'PUT') {
           var body = JSON.stringify(params);
@@ -105,12 +144,24 @@ var request = function (action, method, params, callback, optional) {
           request_options.json = true;
           request_options.body = body,
           Request.put(request_options, function (error, response, body) {
-              if ( error ) {
-                reject( new PlivoError( error ) );
+            if ( error ) {
+              if ( hasCallback ) {
+                callback( new PlivoError( error ) );
               } else {
-                resolve( response );
+                reject( new PlivoError( error ) );
               }
-              //callback(response.statusCode, body);
+            } else {
+              var success = {
+                response: response,
+                body: body
+              };
+
+              if ( hasCallback ) {
+                callback( null, success );
+              } else {
+                resolve( success );
+              }
+            }
           });
       }
     });

--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -4,6 +4,7 @@ var crypto = require('crypto');
 var Request = require('request');
 var qs = require('querystring');
 var xmlBuilder = require('xmlbuilder');
+var Promise = require( 'bluebird' );
 var doc = xmlBuilder.create();
 
 var plivo = {};
@@ -59,39 +60,60 @@ var request = function (action, method, params, callback, optional) {
         json: true,
     };
 
-    if (method == 'POST') {
-        var body = JSON.stringify(params);
+    return new Promise( function ( resolve, reject ) {
+      if (method == 'POST') {
+          var body = JSON.stringify(params);
 
-        request_options.json = true;
-        request_options.body = body;
-        Request.post(request_options, function (error, response, body) {
-            if (error || !response) {
-              return callback(500, body)
-            }
-            if (response.statusCode != 201) {
-                err = new PlivoError(error);
-            }
-            callback(response.statusCode, body);
+          request_options.json = true;
+          request_options.body = body;
+          Request.post(request_options, function (error, response, body) {
+              if (error || !response) {
+                //return callback(500, body)
+                reject( new PlivoError( error ) );
+              } else {
+                resolve( response );
+              }
+              // if (response.statusCode != 201) {
+              //     err = new PlivoError(error);
+              // }
 
-        });
-    } else if (method == 'GET') {
-        request_options.qs = params;
-        Request.get(request_options, function (error, response, body) {
-            callback(response.statusCode, body);
-        });
-    } else if (method == 'DELETE') {
-        Request.del(request_options, function (error, response, body) {
-            callback(response.statusCode, body);
-        });
-    } else if (method == 'PUT') {
-        var body = JSON.stringify(params);
+              //callback(response.statusCode, body);
 
-        request_options.json = true;
-        request_options.body = body,
-        Request.put(request_options, function (error, response, body) {
-            callback(response.statusCode, body);
-        });
-    }
+          });
+      } else if (method == 'GET') {
+          request_options.qs = params;
+          Request.get(request_options, function (error, response, body) {
+              if ( error ) {
+                reject( new PlivoError( error ) );
+              } else {
+                resolve( response );
+              }
+              //callback(response.statusCode, body);
+          });
+      } else if (method == 'DELETE') {
+          Request.del(request_options, function (error, response, body) {
+              if ( error ) {
+                reject( new PlivoError( error ) );
+              } else {
+                resolve( response );
+              }
+              //callback(response.statusCode, body);
+          });
+      } else if (method == 'PUT') {
+          var body = JSON.stringify(params);
+
+          request_options.json = true;
+          request_options.body = body,
+          Request.put(request_options, function (error, response, body) {
+              if ( error ) {
+                reject( new PlivoError( error ) );
+              } else {
+                resolve( response );
+              }
+              //callback(response.statusCode, body);
+          });
+      }
+    });
 };
 
 // Exposing generic request functionality as well.
@@ -145,14 +167,14 @@ plivo.make_call = function (params, callback) {
     var action = 'Call/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_cdrs = function (params, callback) {
     var action = 'Call/';
     var method = 'GET';
 
-    request(action, method, params, callback, true);
+    return request (action, method, params, callback, true);
 };
 
 plivo.get_cdr = function (params, callback) {
@@ -160,7 +182,7 @@ plivo.get_cdr = function (params, callback) {
     delete params.call_uuid;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_live_calls = function (params, callback) {
@@ -168,7 +190,7 @@ plivo.get_live_calls = function (params, callback) {
     var method = 'GET';
 
     params.status = 'live';
-    request(action, method, params, callback, true);
+    return request (action, method, params, callback, true);
 };
 
 plivo.get_live_call = function (params, callback) {
@@ -177,7 +199,7 @@ plivo.get_live_call = function (params, callback) {
     var method = 'GET';
 
     params.status = 'live';
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.transfer_call = function (params, callback) {
@@ -185,7 +207,7 @@ plivo.transfer_call = function (params, callback) {
     delete params.call_uuid;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.hangup_all_calls = function (callback) {
@@ -193,7 +215,7 @@ plivo.hangup_all_calls = function (callback) {
     var method = 'DELETE';
     var params = {};
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.hangup_call = function (params, callback) {
@@ -201,7 +223,7 @@ plivo.hangup_call = function (params, callback) {
     delete params.call_uuid;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.record = function (params, callback) {
@@ -209,7 +231,7 @@ plivo.record = function (params, callback) {
     delete params.call_uuid;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.record_stop = function (params, callback) {
@@ -217,7 +239,7 @@ plivo.record_stop = function (params, callback) {
     delete params.call_uuid;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.play = function (params, callback) {
@@ -225,7 +247,7 @@ plivo.play = function (params, callback) {
     delete params.call_uuid;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.play_stop = function (params, callback) {
@@ -233,7 +255,7 @@ plivo.play_stop = function (params, callback) {
     delete params.call_uuid;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.speak = function (params, callback) {
@@ -241,7 +263,7 @@ plivo.speak = function (params, callback) {
     delete params.call_uuid;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.speak_stop = function (params, callback) {
@@ -249,7 +271,7 @@ plivo.speak_stop = function (params, callback) {
     delete params.call_uuid;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.send_digits = function (params, callback) {
@@ -257,7 +279,7 @@ plivo.send_digits = function (params, callback) {
     delete params.call_uuid;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 // Request
@@ -267,7 +289,7 @@ plivo.hangup_request = function (params, callback) {
     delete params.request_uuid;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 // Conferences
@@ -276,7 +298,7 @@ plivo.get_live_conferences = function (params, callback) {
     var action = 'Conference/';
     var method = 'GET';
 
-    request(action, method, params, callback, true);
+    return request (action, method, params, callback, true);
 };
 
 plivo.get_live_conference = function (params, callback) {
@@ -284,14 +306,14 @@ plivo.get_live_conference = function (params, callback) {
     delete params.conference_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.hangup_all_conferences = function (callback) {
     var action = 'Conference/';
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.hangup_conference = function (params, callback) {
@@ -299,7 +321,7 @@ plivo.hangup_conference = function (params, callback) {
     delete params.conference_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.hangup_conference_member = function (params, callback) {
@@ -308,7 +330,7 @@ plivo.hangup_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.play_conference_member = function (params, callback) {
@@ -317,7 +339,7 @@ plivo.play_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.stop_play_conference_member = function (params, callback) {
@@ -326,7 +348,7 @@ plivo.stop_play_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.speak_conference_member = function (params, callback) {
@@ -336,7 +358,7 @@ plivo.speak_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.stop_speak_conference_member = function (params, callback) {
@@ -345,7 +367,7 @@ plivo.stop_speak_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.deaf_conference_member = function (params, callback) {
@@ -354,7 +376,7 @@ plivo.deaf_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.undeaf_conference_member = function (params, callback) {
@@ -363,7 +385,7 @@ plivo.undeaf_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.mute_conference_member = function (params, callback) {
@@ -372,7 +394,7 @@ plivo.mute_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.unmute_conference_member = function (params, callback) {
@@ -381,7 +403,7 @@ plivo.unmute_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.kick_conference_member = function (params, callback) {
@@ -390,7 +412,7 @@ plivo.kick_conference_member = function (params, callback) {
     delete params.member_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.record_conference = function (params, callback) {
@@ -398,7 +420,7 @@ plivo.record_conference = function (params, callback) {
     delete params.conference_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.stop_record_conference = function (params, callback) {
@@ -406,7 +428,7 @@ plivo.stop_record_conference = function (params, callback) {
     delete params.conference_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 
@@ -416,21 +438,21 @@ plivo.get_account = function (params, callback) {
     var action = '';
     var method = 'GET';
 
-    request(action, method, params, callback, true);
+    return request (action, method, params, callback, true);
 };
 
 plivo.modify_account = function (params, callback) {
     var action = '';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_subaccounts = function (params, callback) {
     var action = 'Subaccount/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_subaccount = function (params, callback) {
@@ -438,14 +460,14 @@ plivo.get_subaccount = function (params, callback) {
     delete params.subauth_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.create_subaccount = function (params, callback) {
     var action = 'Subaccount/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.modify_subaccount = function (params, callback) {
@@ -453,7 +475,7 @@ plivo.modify_subaccount = function (params, callback) {
     delete params.subauth_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.delete_subaccount = function (params, callback) {
@@ -461,7 +483,7 @@ plivo.delete_subaccount = function (params, callback) {
     delete params.subauth_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 // Applications
@@ -470,7 +492,7 @@ plivo.get_applications = function (params, callback) {
     var action = 'Application/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_application = function (params, callback) {
@@ -478,14 +500,14 @@ plivo.get_application = function (params, callback) {
     delete params.app_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.create_application = function (params, callback) {
     var action = 'Application/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.modify_application = function (params, callback) {
@@ -493,7 +515,7 @@ plivo.modify_application = function (params, callback) {
     delete params.app_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.delete_application = function (params, callback) {
@@ -501,7 +523,7 @@ plivo.delete_application = function (params, callback) {
     delete params.app_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 // Recordings
@@ -509,7 +531,7 @@ plivo.get_recordings = function (params, callback) {
     var action = 'Recording/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_recording = function (params, callback) {
@@ -517,7 +539,7 @@ plivo.get_recording = function (params, callback) {
     delete params.recording_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.delete_recording = function (params, callback) {
@@ -525,7 +547,7 @@ plivo.delete_recording = function (params, callback) {
     delete params.recording_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 // Endpoints
@@ -534,7 +556,7 @@ plivo.get_endpoints = function (params, callback) {
     var action = 'Endpoint/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_endpoint = function (params, callback) {
@@ -542,14 +564,14 @@ plivo.get_endpoint = function (params, callback) {
     delete params.endpoint_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.create_endpoint = function (params, callback) {
     var action = 'Endpoint/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.modify_endpoint = function (params, callback) {
@@ -557,7 +579,7 @@ plivo.modify_endpoint = function (params, callback) {
     delete params.endpoint_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.delete_endpoint = function (params, callback) {
@@ -565,7 +587,7 @@ plivo.delete_endpoint = function (params, callback) {
     delete params.endpoint_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 // Numbers
@@ -573,7 +595,7 @@ plivo.get_numbers = function (params, callback) {
     var action = 'Number/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_number_details = function (params, callback) {
@@ -581,7 +603,7 @@ plivo.get_number_details = function (params, callback) {
     delete params.number;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.unrent_number = function (params, callback) {
@@ -589,14 +611,14 @@ plivo.unrent_number = function (params, callback) {
     delete params.number;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_number_group = function (params, callback) {
     var action = 'AvailableNumberGroup/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_number_group_details = function (params, callback) {
@@ -604,7 +626,7 @@ plivo.get_number_group_details = function (params, callback) {
     delete params.group_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.rent_from_number_group = function (params, callback) {
@@ -612,7 +634,7 @@ plivo.rent_from_number_group = function (params, callback) {
     delete params.group_id;
     var method = 'POST';
 
-    request(action, method, params, callback, true);
+    return request (action, method, params, callback, true);
 };
 
 plivo.edit_number = function (params, callback) {
@@ -620,7 +642,7 @@ plivo.edit_number = function (params, callback) {
     delete params.number;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.link_application_number = function (params, callback) {
@@ -636,7 +658,7 @@ plivo.search_phone_numbers = function (params, callback) {
     var action = 'PhoneNumber/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.buy_phone_number = function (params, callback) {
@@ -644,7 +666,7 @@ plivo.buy_phone_number = function (params, callback) {
     delete params.number;
     var method = 'POST';
 
-    request(action, method, params, callback, true);
+    return request (action, method, params, callback, true);
 };
 
 // Message
@@ -652,14 +674,14 @@ plivo.send_message = function (params, callback) {
     var action = 'Message/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_messages = function (params, callback) {
     var action = 'Message/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_message = function (params, callback) {
@@ -667,7 +689,7 @@ plivo.get_message = function (params, callback) {
     delete params.record_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 // Incoming Carriers
@@ -675,7 +697,7 @@ plivo.get_incoming_carriers = function (params, callback) {
     var action = 'IncomingCarrier/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_incoming_carrier = function (params, callback) {
@@ -683,14 +705,14 @@ plivo.get_incoming_carrier = function (params, callback) {
     delete params.carrier_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.create_incoming_carrier = function (params, callback) {
     var action = 'IncomingCarrier/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.modify_incoming_carrier = function (params, callback) {
@@ -698,7 +720,7 @@ plivo.modify_incoming_carrier = function (params, callback) {
     delete params.carrier_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.delete_incoming_carrier = function (params, callback) {
@@ -706,7 +728,7 @@ plivo.delete_incoming_carrier = function (params, callback) {
     delete params.carrier_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 
@@ -715,7 +737,7 @@ plivo.get_outgoing_carriers = function (params, callback) {
     var action = 'OutgoingCarrier/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_outgoing_carrier = function (params, callback) {
@@ -723,14 +745,14 @@ plivo.get_outgoing_carrier = function (params, callback) {
     delete params.carrier_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.create_outgoing_carrier = function (params, callback) {
     var action = 'OutgoingCarrier/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.modify_outgoing_carrier = function (params, callback) {
@@ -738,7 +760,7 @@ plivo.modify_outgoing_carrier = function (params, callback) {
     delete params.carrier_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.delete_outgoing_carrier = function (params, callback) {
@@ -746,7 +768,7 @@ plivo.delete_outgoing_carrier = function (params, callback) {
     delete params.carrier_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 
@@ -755,7 +777,7 @@ plivo.get_outgoing_carrier_routings = function (params, callback) {
     var action = 'OutgoingCarrierRouting/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.get_outgoing_carrier_routing = function (params, callback) {
@@ -763,14 +785,14 @@ plivo.get_outgoing_carrier_routing = function (params, callback) {
     delete params.routing_id;
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.create_outgoing_carrier_routing = function (params, callback) {
     var action = 'OutgoingCarrierRouting/';
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.modify_outgoing_carrier_routing = function (params, callback) {
@@ -778,7 +800,7 @@ plivo.modify_outgoing_carrier_routing = function (params, callback) {
     delete params.routing_id;
     var method = 'POST';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 plivo.delete_outgoing_carrier_routing = function (params, callback) {
@@ -786,7 +808,7 @@ plivo.delete_outgoing_carrier_routing = function (params, callback) {
     delete params.routing_id;
     var method = 'DELETE';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 
@@ -795,7 +817,7 @@ plivo.get_pricing = function (params, callback) {
     var action = 'Pricing/';
     var method = 'GET';
 
-    request(action, method, params, callback);
+    return request (action, method, params, callback);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "xmlbuilder": "~0.4.2",
-    "request": "~2.12.0"
+    "bluebird": "^3.0.5",
+    "request": "~2.12.0",
+    "xmlbuilder": "~0.4.2"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "bluebird": "^3.0.5",
+    "bluebird": "~3.0.5",
     "request": "~2.12.0",
     "xmlbuilder": "~0.4.2"
   },

--- a/test/RestAPI.js
+++ b/test/RestAPI.js
@@ -70,12 +70,25 @@ describe('RestAPI', function() {
                 .reply(204, "");
 
         it('should treat params as callback when params are not provided and optional is true.', function(done) {
-            rest.get_cdrs(function(status, response) {
-                assert.equal(200, status);
-                assert.equal('object', typeof response);
-
+            // rest.get_cdrs(function(status, response) {
+            //     assert.equal(200, status);
+            //     assert.equal('object', typeof response);
+            //
+            //     done();
+            // });
+            rest
+              .get_cdrs()
+              .then( function ( response ) {
+                assert.equal( 'object', typeof response );
+                assert.equal( 200, response.statusCode )
                 done();
-            });
+              })
+              .then( null, function( err ) {
+                  done( err );
+              })
+              .catch( function ( ex ) {
+                done( ex );
+              });
         });
 
         it('should continue when callback is not provided.', function() {
@@ -89,38 +102,81 @@ describe('RestAPI', function() {
         });
 
         it('should successfully send GET requests with parameters.', function(done) {
-            rest.get_cdrs({
-                limit: 5,
-            }, function(status, response) {
-                // if 200 is returned, then nock successfully found the right url
-                assert.equal(200, status);
-                assert.equal('object', typeof response);
-
+            // rest.get_cdrs({
+            //     limit: 5,
+            // }, function(status, response) {
+            //     // if 200 is returned, then nock successfully found the right url
+            //     assert.equal(200, status);
+            //     assert.equal('object', typeof response);
+            //
+            //     done();
+            // });
+            rest
+              .get_cdrs( {limit: 5} )
+              .then( function ( response ) {
+                assert.equal( 'object', typeof response );
+                assert.equal( 200, response.statusCode )
                 done();
-            });
+              })
+              .then( null, function( err ) {
+                  done( err );
+              })
+              .catch( function ( ex ) {
+                done( ex );
+              })
         });
 
         it('should successfully send POST requests.', function(done) {
-            rest.make_call({
+            // rest.make_call({
+            //     answer_url: 'http://test.com',
+            //     to: '1234567890',
+            //     from: '1234567890',
+            // }, function(status, response) {
+            //     assert.equal(201, status);
+            //     assert.equal('object', typeof response);
+            //
+            //     done();
+            // });
+
+            rest
+              .make_call({
                 answer_url: 'http://test.com',
                 to: '1234567890',
-                from: '1234567890',
-            }, function(status, response) {
-                assert.equal(201, status);
-                assert.equal('object', typeof response);
-
+                from: '1234567890'
+              })
+              .then( function ( response ) {
+                assert.equal( 'object', typeof response );
+                assert.equal( 201, response.statusCode );
                 done();
-            });
+              })
+              .then( null, function( err ) {
+                  done( err );
+              })
+              .catch( function ( ex ) {
+                done( ex );
+              })
         });
 
         it('should successfully send DELETE requests.', function(done) {
-            rest.hangup_all_calls(function(status, response) {
-                assert.equal(204, status);
-                assert.equal('string', typeof response);
-                assert.equal('', response);
-
+            // rest.hangup_all_calls(function(status, response) {
+            //     assert.equal(204, status);
+            //     assert.equal('string', typeof response);
+            //     assert.equal('', response);
+            //
+            //     done();
+            // });
+            rest
+              .hangup_all_calls()
+              .then( function ( response ) {
+                assert.equal( 204, response.statusCode )
                 done();
-            });
+              })
+              .then( null, function( err ) {
+                  done( err );
+              })
+              .catch( function ( ex ) {
+                done( ex );
+              })
         });
     });
 
@@ -133,21 +189,21 @@ describe('RestAPI', function() {
 		it('should match signature of plain text', function(done) {
 			var params = { 'ascii': ' !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~' };
 			var test_signature = rest.create_signature('https://' + rest.options.host, params);
-		
+
 			assert.equal('pNTHTayG6CHS3s2c7AbsJUYIrno=', test_signature);
 
 			done();
-	
+
 		});
 
 		it('should match signature of utf-8 text', function(done) {
 			var params = { 'utf': '\xC4\xA4\xC4\x98\xC4\xBD\xC4\xBF\xC5\x8C\xC2\xA0\xE1\xBA\x80\xCE\xB8\xC5\x94\xC4\xBD\xE1\xB8\x8A\xE2\x80\xA6\xC2\xA9\xF0\x9D\x8C\x86\xE2\x98\x83\xF0\x9F\x98\x80\xF0\x9F\x98\x81\xF0\x9F\x98\x82\xF0\x9F\x98\x83\xF0\x9F\x98\x84\xF0\x9F\x98\x85\xF0\x9F\x98\x86\xF0\x9F\x98\x87' };
 			var test_signature = rest.create_signature('https://' + rest.options.host, params);
-	
+
 			assert.equal('0gQVBqlj63pjoVO6dHmGJsEajS4=', test_signature);
 
 			done();
-		
+
 		});
 	});
 

--- a/test/RestAPI.js
+++ b/test/RestAPI.js
@@ -70,25 +70,16 @@ describe('RestAPI', function() {
                 .reply(204, "");
 
         it('should treat params as callback when params are not provided and optional is true.', function(done) {
-            // rest.get_cdrs(function(status, response) {
-            //     assert.equal(200, status);
-            //     assert.equal('object', typeof response);
-            //
-            //     done();
-            // });
-            rest
-              .get_cdrs()
-              .then( function ( response ) {
-                assert.equal( 'object', typeof response );
-                assert.equal( 200, response.statusCode )
-                done();
-              })
-              .then( null, function( err ) {
-                  done( err );
-              })
-              .catch( function ( ex ) {
-                done( ex );
-              });
+            rest.get_cdrs(function( error, response ) {
+                if ( error ) {
+                  done( error )
+                } else {
+                  assert.equal( 'object', typeof response);
+                  assert.equal( 200, response.response.statusCode );
+
+                  done();
+                }
+            });
         });
 
         it('should continue when callback is not provided.', function() {
@@ -115,7 +106,7 @@ describe('RestAPI', function() {
               .get_cdrs( {limit: 5} )
               .then( function ( response ) {
                 assert.equal( 'object', typeof response );
-                assert.equal( 200, response.statusCode )
+                assert.equal( 200, response.response.statusCode )
                 done();
               })
               .then( null, function( err ) {
@@ -146,7 +137,7 @@ describe('RestAPI', function() {
               })
               .then( function ( response ) {
                 assert.equal( 'object', typeof response );
-                assert.equal( 201, response.statusCode );
+                assert.equal( 201, response.response.statusCode );
                 done();
               })
               .then( null, function( err ) {
@@ -168,7 +159,7 @@ describe('RestAPI', function() {
             rest
               .hangup_all_calls()
               .then( function ( response ) {
-                assert.equal( 204, response.statusCode )
+                assert.equal( 204, response.response.statusCode )
                 done();
               })
               .then( null, function( err ) {


### PR DESCRIPTION
Cleaned up callback implementation and added support for promises ([bluebird](https://github.com/petkaantonov/bluebird/)). This is an intrusive update and changes the structure of a callback/promise success response. All _error_ cases contain a `PlivoError` wrapped `Error`. It passes back both the response and body for the _success_ case:

`{response: response, body: body}`

I've updated the tests as well. 
#### Callback example:

```
plivo.send_message( {...}, function ( error, success ) {
    if ( error ) {
        assert( error instanceof PlivoError );
    } else {
        assert( success.response );
        assert( success.body );
    }
});
```
#### Promise example

```
plivo
    .send_message( {...} )
    .then( function( success ) {
        assert( success.response );
        assert( success.body );
    })
    .then( null, function( error ) {
        assert( error instanceof PlivoError );
    })
    .catch( function( ex ) {
        assert( error instanceof PlivoError );
    })
```
