### PR TITLE
replaces '<your AUTH ID>' with process.env.authId and same for token

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ REST API
 var plivo = require('plivo');
 
 var api = plivo.RestAPI({
-  authId: '<your AUTH ID>',
-  authToken: '<your AUTH TOKEN>',
+  authId: process.env.authId,
+  authToken: process.env.authToken,
 });
 ```
 


### PR DESCRIPTION
I've also made this change in plivo/plivo-examples-node: See https://github.com/plivo/plivo-examples-node/pull/11.
