### PR TITLE
Add optional network timeout to all calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #plivo-node
-[![NPM version](https://badge.fury.io/js/plivo-node.png)](http://badge.fury.io/js/plivo-node)  [![Build Status](https://secure.travis-ci.org/plivo/plivo-node.png?branch=master)](http://travis-ci.org/plivo/plivo-node) 
+[![NPM version](https://badge.fury.io/js/plivo-node.png)](http://badge.fury.io/js/plivo-node)  [![Build Status](https://secure.travis-ci.org/plivo/plivo-node.png?branch=master)](http://travis-ci.org/plivo/plivo-node)
 
 Node.js helper library for the [Plivo](http://plivo.com) API, to create powerful Voice and SMS applications.
 
@@ -50,7 +50,7 @@ var plivo = require('plivo');
 
 var api = plivo.RestAPI({
   authId: '<your AUTH ID>',
-  authToken: '<your AUTH TOKEN>',
+  authToken: '<your AUTH TOKEN>'
 });
 ```
 
@@ -66,7 +66,7 @@ So for example, to make a call, you may do something like this:
 /**
  * api.make_call accepts params and callback
  */
- 
+
 // Keys and values to be used for params are the same as documented for our REST API.
 // So for using RestAPI.make_call, valid params can be checked
 // at https://www.plivo.com/docs/api/call/#outbound.
@@ -101,6 +101,21 @@ api.get_cdrs({ limit: 10 }, function(status, response) {
 });
 ```
 
+#### Timeout
+
+A custom timeout can be specified for all network requests made through the api. Just specify a `timeout` value in milliseconds.
+
+```
+var plivo = require('plivo');
+
+var api = plivo.RestAPI({
+  authId: '<your AUTH ID>',
+  authToken: '<your AUTH TOKEN>',
+  timeout: 0 // Default value (no timeout).
+});
+```
+
+If the request is aborted because of a timeout, a status code `408` will be returned and an undefined response body. Note that this timeout value affects both connection timeouts and server timeouts. Therefore, with a timeout value of `1000`, the request can take no more than 2 seconds (up to 1000 milliseconds to connect and up to 1000 milliseconds for the server to give a response).
 
 XML Generation
 ---------------
@@ -220,5 +235,3 @@ References
 ----------
 * [Plivo API Documentation and Concepts](https://www.plivo.com/docs/)
 * [Examples](http://github.com/plivo/plivo-examples-node)
-
- 

--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -26,6 +26,19 @@ function PlivoError(msg) {
 
 PlivoError.prototype = Error.prototype;
 
+
+
+function handleTimeout (user_callback, internal_handler) {
+  return function (error, response, body) {
+    // As per https://en.wikipedia.org/wiki/List_of_HTTP_status_codes, 408 is a reasonable code to return if there's a timeout.
+    if (error && error.code === 'ETIMEDOUT') {
+      user_callback(408);
+    } else {
+      internal_handler(error, response, body);
+    }
+  }
+}
+
 // Main request function
 var request = function (action, method, params, callback, optional) {
     if (optional) {
@@ -57,6 +70,7 @@ var request = function (action, method, params, callback, optional) {
         uri: path,
         headers: headers,
         json: true,
+        timeout: plivo.options.timeout || 0
     };
 
     if (method == 'POST') {
@@ -64,7 +78,7 @@ var request = function (action, method, params, callback, optional) {
 
         request_options.json = true;
         request_options.body = body;
-        Request.post(request_options, function (error, response, body) {
+        Request.post(request_options, handleTimeout(callback, function (error, response, body) {
             if (error || !response) {
               return callback(500, body)
             }
@@ -73,24 +87,24 @@ var request = function (action, method, params, callback, optional) {
             }
             callback(response.statusCode, body);
 
-        });
+        }));
     } else if (method == 'GET') {
         request_options.qs = params;
-        Request.get(request_options, function (error, response, body) {
+        Request.get(request_options, handleTimeout(callback, function (error, response, body) {
             callback(response.statusCode, body);
-        });
+        }));
     } else if (method == 'DELETE') {
-        Request.del(request_options, function (error, response, body) {
+        Request.del(request_options, handleTimeout(callback, function (error, response, body) {
             callback(response.statusCode, body);
-        });
+        }));
     } else if (method == 'PUT') {
         var body = JSON.stringify(params);
 
         request_options.json = true;
         request_options.body = body,
-        Request.put(request_options, function (error, response, body) {
+        Request.put(request_options, handleTimeout(callback, function (error, response, body) {
             callback(response.statusCode, body);
-        });
+        }));
     }
 };
 

--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -74,9 +74,8 @@ var request = function (action, method, params, callback, optional) {
     };
 
     if (method == 'POST') {
-        var body = JSON.stringify(params);
+        var body = params;
 
-        request_options.json = true;
         request_options.body = body;
         Request.post(request_options, handleTimeout(callback, function (error, response, body) {
             if (error || !response) {
@@ -98,9 +97,8 @@ var request = function (action, method, params, callback, optional) {
             callback(response.statusCode, body);
         }));
     } else if (method == 'PUT') {
-        var body = JSON.stringify(params);
+        var body = params;
 
-        request_options.json = true;
         request_options.body = body,
         Request.put(request_options, handleTimeout(callback, function (error, response, body) {
             callback(response.statusCode, body);

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "xmlbuilder": "~0.4.2",
-    "request": "~2.12.0"
+    "request": "~2.67.0"
   },
   "directories": {
     "test": "test"
   },
   "devDependencies": {
-    "nock": "~0.14.2",
+    "nock": "~7.5.0",
     "mocha": "~1.7.4"
   },
   "scripts": {

--- a/test/RestAPI.js
+++ b/test/RestAPI.js
@@ -57,17 +57,18 @@ describe('RestAPI', function() {
             authToken: '0123456789abc',
         });
 
-        var endpoint = nock('https://' + rest.options.host + ':443');
-        endpoint.get('/v1/Account/0123456789/Call/?')
-                .reply(200, JSON.stringify({}))
+        var endpoint = nock('https://' + rest.options.host);
+        endpoint.get('/v1/Account/0123456789/Call/')
+                .reply(200, {})
                 .get('/v1/Account/0123456789/Call/?limit=5')
-                .reply(200, JSON.stringify({}))
-                .get('/v1/Account/0123456789/Call/xxxxxxxxxxxxxxxxx/?')
-                .reply(200, JSON.stringify({}))
-                .post('/v1/Account/0123456789/Call/', "{\"answer_url\":\"http://test.com\",\"to\":\"1234567890\",\"from\":\"1234567890\"}")
-                .reply(201, JSON.stringify({}))
+                .reply(200, {})
+                .get('/v1/Account/0123456789/Call/xxxxxxxxxxxxxxxxx/')
+                .reply(200, {})
+                .post('/v1/Account/0123456789/Call/',
+                JSON.stringify('{"answer_url":"http://test.com","to":"1234567890","from":"1234567890"}'))
+                .reply(201, {})
                 .delete('/v1/Account/0123456789/Call/')
-                .reply(204, "");
+                .reply(204, 'ok');
 
         it('should treat params as callback when params are not provided and optional is true.', function(done) {
             rest.get_cdrs(function(status, response) {
@@ -117,7 +118,7 @@ describe('RestAPI', function() {
             rest.hangup_all_calls(function(status, response) {
                 assert.equal(204, status);
                 assert.equal('string', typeof response);
-                assert.equal('', response);
+                assert.equal('ok', response);
 
                 done();
             });
@@ -133,21 +134,21 @@ describe('RestAPI', function() {
 		it('should match signature of plain text', function(done) {
 			var params = { 'ascii': ' !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~' };
 			var test_signature = rest.create_signature('https://' + rest.options.host, params);
-		
+
 			assert.equal('pNTHTayG6CHS3s2c7AbsJUYIrno=', test_signature);
 
 			done();
-	
+
 		});
 
 		it('should match signature of utf-8 text', function(done) {
 			var params = { 'utf': '\xC4\xA4\xC4\x98\xC4\xBD\xC4\xBF\xC5\x8C\xC2\xA0\xE1\xBA\x80\xCE\xB8\xC5\x94\xC4\xBD\xE1\xB8\x8A\xE2\x80\xA6\xC2\xA9\xF0\x9D\x8C\x86\xE2\x98\x83\xF0\x9F\x98\x80\xF0\x9F\x98\x81\xF0\x9F\x98\x82\xF0\x9F\x98\x83\xF0\x9F\x98\x84\xF0\x9F\x98\x85\xF0\x9F\x98\x86\xF0\x9F\x98\x87' };
 			var test_signature = rest.create_signature('https://' + rest.options.host, params);
-	
+
 			assert.equal('0gQVBqlj63pjoVO6dHmGJsEajS4=', test_signature);
 
 			done();
-		
+
 		});
 	});
 

--- a/test/RestAPI.js
+++ b/test/RestAPI.js
@@ -123,6 +123,57 @@ describe('RestAPI', function() {
                 done();
             });
         });
+
+        describe('timeout', function() {
+            beforeEach(function() {
+              rest.options.timeout = 1; // Quickly terminate all network requests.
+            });
+
+            afterEach(function() {
+              rest.options.timeout = undefined;
+            });
+
+            it('should observe the user-defined timeout on GET requests.', function(done) {
+                endpoint.get('/v1/Account/0123456789/Call/').delay(1000).reply(200);
+                rest.get_cdrs(function(status, response) {
+                    assert.equal(408, status);
+                    assert.equal('undefined', typeof response);
+
+                    done();
+                });
+            });
+
+            it('should observe the user-defined timeout on POST requests.', function(done) {
+                endpoint.post('/v1/Account/0123456789/Call/').delay(1000).reply(200);
+                rest.make_call({}, function(status, response) {
+                    assert.equal(408, status);
+                    assert.equal('undefined', typeof response);
+
+                    done();
+                });
+            });
+
+            it('should observe the user-defined timeout on DELETE requests.', function(done) {
+                endpoint.delete('/v1/Account/0123456789/Call/').delay(1000).reply(200);
+                rest.hangup_all_calls(function(status, response) {
+                    assert.equal(408, status);
+                    assert.equal('undefined', typeof response);
+
+                    done();
+                });
+            });
+
+            it('should not time out all requests', function(done) {
+                rest.options.timeout = 100;
+                endpoint.get('/v1/Account/0123456789/Call/').delay(10).reply(200, {});
+                rest.get_cdrs(function(status, response) {
+                    assert.equal(200, status);
+                    assert.equal('object', typeof response);
+
+                    done();
+                });
+            })
+        });
     });
 
 	describe('create_signature()', function() {


### PR DESCRIPTION
This PR allows users to specify a network timeout for all calls made through `plivo-node`. This was prompted after our scheduler locked up because a single network request to Plivo hung for some unexplainable reason.

I've included tests and an updated readme to reflect the changes.

Note that I only use the library for sending text messages. I don't know if there are any specific network request (maybe phone calls) that require a long-running connection. Those might break horribly if a timeout is applied to them.

Also note that I had to upgrade some dependencies (`nock` and `requests`) to support timeouts on requests and testing them.

Previously, there was no timeout on any network requests and without any users changing existing code, there still isn't a network timeout for any requests. There is only a timeout in place for requests if users explicitly update their code to request one. I've copied the new section of the readme below for reference:

<hr>
#### Timeout

A custom timeout can be specified for all network requests made through the api. Just specify a `timeout` value in milliseconds.

```
var plivo = require('plivo');

var api = plivo.RestAPI({
  authId: '<your AUTH ID>',
  authToken: '<your AUTH TOKEN>',
  timeout: 0 // Default value (no timeout).
});
```

If the request is aborted because of a timeout, a status code `408` will be returned and an undefined response body. Note that this timeout value affects both connection timeouts and server timeouts. Therefore, with a timeout value of `1000`, the request can take no more than 2 seconds (up to 1000 milliseconds to connect and up to 1000 milliseconds for the server to give a response).
