### PR TITLE
Allow to set the addUser attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ OUTPUTS to screen:
 * `add<XML Element>`: there are many methods that follow this kind of naming pattern. Replace `<XML Element>` with any valid XML element listed on https://www.plivo.com/docs/xml/. Some of these methods accept `body` param (a string) as an argument, some accept `attributes` (an object that is a map of valid attributes of the `<XML Element>`) as an argument and some accept both. Which method accepts which paramter depends upon the element.
   * `addConference`: accepts `body` and `attributes` as arguments
   * `addNumber`: accepts `body` and `attributes` as arguments
-  * `addUser`: accepts `body` as argument
+  * `addUser`: accepts `body` and `attributes` as arguments
   * `addDial`: accepts `attributes` as argument
   * `addGetDigits`: accepts `attributes` as argument
   * `addHangup`: accepts `attributes` as argument

--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -864,8 +864,8 @@ Response.prototype = {
         return this.add(new Number(Response), body, attributes);
     },
 
-    addUser: function (body) {
-        return this.add(new User(Response), body, {});
+    addUser: function (body, attributes) {
+        return this.add(new User(Response), body, attributes);
     },
 
     addDial: function (attributes) {


### PR DESCRIPTION
Allow to set the addUser attributes as specified at: https://www.plivo.com/docs/xml/user/

Right now there is no way to send "sendDigits", "sendOnPreanswer" or "sipHeaders" attributes when someone use the "addUser" method.
