### PR TITLE
Fixes reference to create_signature after prototype change

### DIFF
--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -101,6 +101,9 @@ plivo.prototype.create_signature = function (url, params) {
 
 // Express middleware for verifying signature
 plivo.prototype.middleware = function(options) {
+
+  var instance = this;
+
   return function (req, res, next) {
     if (process.env.NODE_ENV === 'test') return next()
 
@@ -112,7 +115,7 @@ plivo.prototype.middleware = function(options) {
     }
     toSign += req.originalUrl;
 
-    var expectedSignature = plivo.create_signature(toSign, req.body);
+    var expectedSignature = instance.create_signature(toSign, req.body);
 
     if (expectedSignature === req.header('X-Plivo-Signature')) {
       next();


### PR DESCRIPTION
After the change to move all methods under **plivo.prototype** (36febb2ce6df063abf8db45e8fa552264bdbcf43), calling **create_signature** from **plivo.prototype.middleware()** fails.

Fixed so that **create_signature** is called from the current plivo instance.