### PR TITLE
Fix signature check for URLs with query strings requiring encoding

### DIFF
--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -85,7 +85,7 @@ plivo.prototype.request = function (action, method, params, callback, optional) 
 
 // For verifying the plivo server signature
 plivo.prototype.create_signature = function (url, params) {
-  var toSign = url;
+  var toSign = decodeURI(url);
 
   Object.keys(params).sort().forEach(function(key) {
     toSign += key + params[key];

--- a/test/RestAPI.js
+++ b/test/RestAPI.js
@@ -188,6 +188,13 @@ describe('RestAPI', function() {
 			done();
 		
 		});
+
+                it('should match signature when URI requires encoding', function(done) {
+                        var query_string = '/?test=needs%20encoding';
+                        var test_signature = rest.create_signature('https://' + rest.options.host + query_string, {});
+                        assert.equal('nZsvPk6VyueGOBSXGAv+blNoiQ8=', test_signature);
+                        done();
+                });
 	});
 
 });


### PR DESCRIPTION
The signature check algorithm differs to what is generated by plivo. The error occurs when the middleware receives a post with a url with encoded parameters e.g. `https://test.com/test?encode=with%20space`.