### PR TITLE
Update to Buffer call when forming an auth token

### DIFF
--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -2,7 +2,7 @@ import request from 'request';
 import queryString from 'querystring';
 
 export function Request(config) {
-  let auth = 'Basic ' + new Buffer(config.authId + ':' + config.authToken)
+  let auth = 'Basic ' + Buffer.from(config.authId + ':' + config.authToken)
     .toString('base64');
 
   let headers = {

--- a/lib/rest/request.js
+++ b/lib/rest/request.js
@@ -4,7 +4,7 @@ import * as Exceptions from '../utils/exceptions';
 import * as _ from "lodash";
 
 export function Request(config) {
-  let auth = 'Basic ' + new Buffer(config.authId + ':' + config.authToken)
+  let auth = 'Basic ' + Buffer.from(config.authId + ':' + config.authToken)
     .toString('base64');
 
   let headers = {


### PR DESCRIPTION
Small fix for deprecated Buffer call. Now using Buffer.from() for strings, this removes the DEP warning that occurs at run time. Buffer.alloc() would be used for numbers, but I did a quick check and didn't find any usage of that.

<img width="1128" alt="Screen Shot 2020-09-09 at 9 17 18 AM" src="https://user-images.githubusercontent.com/70023244/92658764-ba348900-f2bc-11ea-9cd3-ea6870375153.png">

