### PR TITLE
Add support for Lookup API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [4.10.0](https://github.com/plivo/plivo-node/releases/tag/v4.10.0)(2020-09-15)
+## [4.10.0](https://github.com/plivo/plivo-node/releases/tag/v4.10.0)(2020-09-21)
 -  Add Lookup API support.
 
 ## [4.9.0](https://github.com/plivo/plivo-node/releases/tag/v4.8.0)(2020-08-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [4.10.0](https://github.com/plivo/plivo-node/releases/tag/v4.10.0)(2020-09-15)
+-  Add Lookup API support.
+
 ## [4.9.0](https://github.com/plivo/plivo-node/releases/tag/v4.8.0)(2020-08-25)
 -  Add Powerpack for MMS
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ client.calls.create(
 
 ```
 
+### Lookup a number
+
+```javascript
+let plivo = require('plivo');
+let client = new plivo.Client('AUTH_ID', 'AUTH_TOKEN');
+
+client.lookup.get(
+    "<number-goes-here>",
+    "service_provider"  // default info
+).then(function(response) {
+    console.log(response);
+}).catch(function(error) {
+    console.log(error);
+});
+```
+
 ### Generate Plivo XML
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ let client = new plivo.Client('AUTH_ID', 'AUTH_TOKEN');
 
 client.lookup.get(
     "<number-goes-here>",
-    "service_provider"  // default info
+    "carrier"  // default type
 ).then(function(response) {
     console.log(response);
 }).catch(function(error) {

--- a/examples/lookup.js
+++ b/examples/lookup.js
@@ -3,7 +3,7 @@ let client = new plivo.Client('', '');
 
 client.lookup.get(
     "",
-    "service_provider" // default info
+    "carrier" // default info
 ).then(function(response) {
     console.log(response);
 }).catch(function(error) {

--- a/examples/lookup.js
+++ b/examples/lookup.js
@@ -1,0 +1,11 @@
+let plivo = require('plivo');
+let client = new plivo.Client('', '');
+
+client.lookup.get(
+    "",
+    "service_provider" // default info
+).then(function(response) {
+    console.log(response);
+}).catch(function(error) {
+    console.log(error);
+});

--- a/lib/resources/lookup.js
+++ b/lib/resources/lookup.js
@@ -30,7 +30,7 @@ export class LookupInterface extends PlivoResourceInterface {
         this[clientKey] = client;
     }
 
-    get(number, info = 'service_provider') {
+    get(number, type = 'carrier') {
         let errors = validate([{
             field: 'number',
             value: number,
@@ -42,7 +42,7 @@ export class LookupInterface extends PlivoResourceInterface {
         }
 
         let params = {
-            info: info,
+            type: type,
             overrideUrl: `${LOOKUP_API_BASE_URL}/${number}`,
         };
 

--- a/lib/resources/lookup.js
+++ b/lib/resources/lookup.js
@@ -1,0 +1,51 @@
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+import {
+    PlivoResource,
+    PlivoResourceInterface
+} from '../base';
+
+import * as _ from "lodash";
+
+const clientKey = Symbol();
+const action = 'Lookup/Number/'; // unused as it is overridden, only for unit tests
+const idField = 'OVERRIDDEN';
+const LOOKUP_API_BASE_URL = 'https://api.plivo.com/v1/Lookup/Number'
+
+export class Number extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, Number, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+    }
+}
+
+export class LookupInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, Number, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+    }
+
+    get(number, info = 'service_provider') {
+        let errors = validate([{
+            field: 'number',
+            value: number,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let params = {
+            info: info,
+            overrideUrl: `${LOOKUP_API_BASE_URL}/${number}`,
+        };
+
+        return super.get(number, params);
+    }
+}

--- a/lib/rest/client-test.js
+++ b/lib/rest/client-test.js
@@ -28,6 +28,9 @@ import {
   MessageInterface
 } from '../resources/messages.js';
 import {
+  LookupInterface
+} from '../resources/lookup.js';
+import {
   PowerpackInterface
 } from '../resources/powerpacks.js';
 import {
@@ -81,6 +84,7 @@ export class Client {
     this.conferences = new ConferenceInterface(client);
     this.endpoints = new EndpointInterface(client);
     this.messages = new MessageInterface(client);
+    this.lookup = new LookupInterface(client);
     this.powerpacks = new PowerpackInterface(client);
     this.numbers = new NumberInterface(client);
     this.pricings = new PricingInterface(client);

--- a/lib/rest/client.js
+++ b/lib/rest/client.js
@@ -8,6 +8,7 @@ import { ApplicationInterface } from "../resources/applications";
 import { ConferenceInterface } from "../resources/conferences";
 import { EndpointInterface } from "../resources/endpoints";
 import { MessageInterface } from "../resources/messages";
+import { LookupInterface } from "../resources/lookup";
 import { PowerpackInterface } from "../resources/powerpacks";
 import { NumberInterface } from "../resources/numbers";
 import { PricingInterface } from "../resources/pricings";
@@ -75,6 +76,7 @@ export class Client {
     this.conferences = new ConferenceInterface(client);
     this.endpoints = new EndpointInterface(client);
     this.messages = new MessageInterface(client);
+    this.lookup = new LookupInterface(client);
     this.powerpacks = new PowerpackInterface(client);
     this.numbers = new NumberInterface(client);
     this.pricings = new PricingInterface(client);

--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -911,24 +911,26 @@ export function Request(config) {
           response: {},
 	  body: {
 	    api_id: "930692a3-6f09-45b5-80f5-5585565fb30e",
+            phone_number: "+14154305555",
 	    country: {
 		code_iso2: "US",
 		code_iso3: "USA",
 		name: "United States"
 	    },
-	    number_format: {
+	    format: {
 		e164: "+14154305555",
 		international: "+1 415-430-5555",
 		national: "(415) 430-5555",
 		rfc3966: "tel:+1-415-430-5555"
 	    },
-	    service_provider: {
+	    carrier: {
 		mobile_country_code: "310",
 		mobile_network_code: "160",
 		name: "Cingular Wireless",
 		ported: true,
 		type: "mobile"
-	    }
+	    },
+            resource_uri: "/v1/Lookup/Number/+14154305555?type=carrier"
 	  }
         });
       }

--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -905,6 +905,34 @@ export function Request(config) {
         });
       }
 
+      // ============= Lookup ===================
+      else if (action == 'Lookup/Number/+14154305555' && method == 'GET') {
+        resolve({
+          response: {},
+	  body: {
+	    api_id: "930692a3-6f09-45b5-80f5-5585565fb30e",
+	    country: {
+		code_iso2: "US",
+		code_iso3: "USA",
+		name: "United States"
+	    },
+	    number_format: {
+		e164: "+14154305555",
+		international: "+1 415-430-5555",
+		national: "(415) 430-5555",
+		rfc3966: "tel:+1-415-430-5555"
+	    },
+	    service_provider: {
+		mobile_country_code: "310",
+		mobile_network_code: "160",
+		name: "Cingular Wireless",
+		ported: true,
+		type: "mobile"
+	    }
+	  }
+        });
+      }
+
       // =============  Pricings ===================
       else if (method == 'GET' && action == 'Pricing/') {
         resolve({

--- a/lib/rest/request.js
+++ b/lib/rest/request.js
@@ -47,6 +47,11 @@ export function Request(config) {
         options.url = apiVoiceUris[0] + config.authId + '/' + action;
         delete params.is_voice_request;
         isVoiceReq = true;
+      } else if (params.hasOwnProperty('override_url')) {
+        // currently used by Lookup API but is generic enough to be used
+        // by any product in future.
+        options.url = params.override_url;
+        delete params.override_url;
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/test/lookup.js
+++ b/test/lookup.js
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import {
+    Client
+} from '../lib/rest/client-test';
+import {
+    PlivoGenericResponse
+} from '../lib/base.js';
+
+let client = new Client('sampleid', 'sammpletoken', 'sampleproxy');
+
+describe('LookupInterface', function() {
+    it('should lookup number', function() {
+        return client.lookup.get('+14154305555')
+            .then(function(number) {
+                assert.equal(number.numberFormat.e164, '+14154305555')
+            })
+    });
+});

--- a/test/lookup.js
+++ b/test/lookup.js
@@ -14,6 +14,8 @@ describe('LookupInterface', function() {
         return client.lookup.get('+14154305555')
             .then(function(number) {
                 assert.equal(number.numberFormat.e164, '+14154305555')
+                assert.equal(number.phoneNumber, '+14154305555')
+                assert.equal(number.resourceUri, '/v1/Lookup/Number/+14154305555?type=carrier')
             })
     });
 });


### PR DESCRIPTION
Sample program:

```js
let plivo = require('plivo');
let client = new plivo.Client('XXXX', 'XXXX');

client.lookup.get(
    "+14154305555",
    "carrier"
).then(function(response) {
    console.log(response);
}).catch(function(error) {
    console.log(error);
});
```

Output:

```sh
$ node app.js
Number {
  apiId: '44c2be08-e2aa-4a88-89a3-a2e9eccccef9',
  phoneNumber: '+14154305555',
  country: { name: 'United States', codeIso2: 'US', codeIso3: 'USA' },
  format:
   { e164: '+14154305555',
     national: '(415) 430-5555',
     international: '+1 415-430-5555',
     rfc3966: 'tel:+1-415-430-5555' },
  carrier:
   { mobileCountryCode: '310',
     mobileNetworkCode: '150',
     name: 'Cingular Wireless',
     type: 'mobile',
     ported: true },
  resourceUri: '/v1/Lookup/Number/+14154305555?type=carrier' }
```