### PR TITLE
support powerpack id filter for list mdr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
-## [v4.20.0](https://github.com/plivo/plivo-node/tree/v4.20.0) (2021-07-06)
-- Powerpack ID filter for list MDR
+
+## [v4.20.0](https://github.com/plivo/plivo-node/tree/v4.20.0) (2021-07-13)
+- Power pack ID has been included to the response for the [list all messages API](https://www.plivo.com/docs/sms/api/message/list-all-messages/) and the [get message details API](https://www.plivo.com/docs/sms/api/message#retrieve-a-message).
+- Support for filtering messages by Power pack ID has been added to the [list all messages API](https://www.plivo.com/docs/sms/api/message#list-all-messages).
 
 ## [v4.19.2](https://github.com/plivo/plivo-node/tree/v4.19.2) (2021-07-08)
 - MPC SDK fixes to pass params in a user-friendly manner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## [v4.20.0](https://github.com/plivo/plivo-node/tree/v4.20.0) (2021-07-06)
+- Powerpack ID filter for list MDR
 
 ## [v4.19.1](https://github.com/plivo/plivo-node/tree/v4.19.1) (2021-07-05)
 - **WARNING**: Removed the total_count parameter in meta data for list MDR response

--- a/lib/resources/messages.js
+++ b/lib/resources/messages.js
@@ -42,6 +42,7 @@ export class MessageGetResponse {
         this.totalAmount = params.totalAmount;
         this.totalRate = params.totalRate;
         this.units = params.units;
+        this.powerpackID = params.powerpackId
     }
 }
 
@@ -60,6 +61,7 @@ export class MessageListResponse {
         this.totalAmount = params.totalAmount;
         this.totalRate = params.totalRate;
         this.units = params.units;
+        this.powerpackID = params.powerpackId;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.19.1",
+  "version": "4.20.0",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/types/resources/messages.d.ts
+++ b/types/resources/messages.d.ts
@@ -19,6 +19,7 @@ export class MessageGetResponse {
 	totalAmount: string;
 	totalRate: string;
 	units: string;
+	powerpackId: string;
 }
 export class MessageListResponse {
 	constructor(params: object);
@@ -34,6 +35,7 @@ export class MessageListResponse {
 	totalAmount: string;
 	totalRate: string;
     units: string;
+	powerpackId: string;
 }
 export class MMSMediaResponse {
 	constructor(params: object);


### PR DESCRIPTION
- supporting powerpack id filter for listing mdr.

sample code: 
`let plivo = require('plivo');
let client = new plivo.Client('xxxx', 'xxxxxx');
client.messages.list(
        {
            limit: 5,
            offset: 0,
            powerpack_id:"15c01cc2-4b9f-4d3b-bd15-3c4b38984cc4",
        }).then(
  function (response) {
    console.log("\n============ response ===========\n",response)
  }
).catch(function (response) {
  console.log("\n============ Error :: ===========\n", response);
});
`