### PR TITLE
handle invalid number response on bulk send sms 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## [v4.22.4](https://github.com/plivo/plivo-node/tree/v4.22.4) (2021-09-27)
+**Bug Fix**
+  - Fix Invalid Destination number response on send sms.
 
 ## [v4.22.3](https://github.com/plivo/plivo-node/tree/v4.22.3) (2021-09-22)
 **Bug Fix**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
+
 ## [v4.22.4](https://github.com/plivo/plivo-node/tree/v4.22.4) (2021-09-27)
 **Bug Fix**
-  - Fix Invalid Destination number response on send sms.
+  - Handle invalid destination number API response for send [SMS API](https://www.plivo.com/docs/sms/api/message/send-a-message/).
 
 ## [v4.22.3](https://github.com/plivo/plivo-node/tree/v4.22.3) (2021-09-22)
 **Bug Fix**

--- a/lib/resources/messages.js
+++ b/lib/resources/messages.js
@@ -22,7 +22,9 @@ export class MessageResponse {
         this.apiId = params.apiId;
         this.message = params.message;
         this.messageUuid = params.messageUuid;
-
+        if (params.invalidNumber != undefined ){
+            this.invalid_number = params.invalidNumber;
+        }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.22.3",
+  "version": "4.22.4",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/types/resources/messages.d.ts
+++ b/types/resources/messages.d.ts
@@ -3,6 +3,7 @@ export class MessageResponse {
 	apiId: string;
 	message: string;
 	messageUuid: Array<string>;
+	invalidNumber?: Array<string>;
 }
 export class MessageGetResponse {
 	constructor(params: object);


### PR DESCRIPTION
case:
1)Valid and Invalid Number:
 ```
MessageResponse {
  apiId: 'xxxxxxxxxxxxx',
  message: 'message(s) queued',
  messageUuid: [ 'xxxxxxxxxxxxxxx' ],
  invalid_number: [ '122' ] } ```

2) Both Invalid Number:
```
{ Error: invalid phone numbers.
  status: 400,
  statusText: 'BAD REQUEST',
  apiID: 'xxxxxxx,
  moreInfo: '{"type":"sms","method":"POST","url":"xxxx","src":"xxxxxx","dst":"4111<<122","text":"xxxx"}' } ```
3) Valid Number:
   ```apiId: 'xxxxxxxxxxxxx',
  message: 'message(s) queued',
  messageUuid: [ 'xxxxxxxxxxxxxxx' ]```
