### PR TITLE
Typescript fixes

### DIFF
--- a/types/resources/numbers.d.ts
+++ b/types/resources/numbers.d.ts
@@ -48,7 +48,7 @@ export class PhoneNumber extends PlivoResource {
 	 * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
 	 * @fail {Error} return Error
 	 */
-	buy(appId: string): Promise < any > ;
+	buy(appId?: string): Promise < any > ;
 	[clientKey]: symbol;
 }
 /**
@@ -67,7 +67,7 @@ export class PhoneNumberInterface extends PlivoResourceInterface {
 	 * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
 	 * @fail {Error} return Error
 	 */
-	buy(number: string, appId: string): Promise < any > ;
+	buy(number: string, appId?: string): Promise < any > ;
 	[clientKey]: symbol;
 }
 /**
@@ -104,7 +104,7 @@ export class NumberInterface extends PlivoResourceInterface {
 	 * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
 	 * @fail {Error} return Error
 	 */
-	buy(number: string, appId: string): Promise < BuyNumberResponse > ;
+	buy(number: string, appId?: string): Promise < BuyNumberResponse > ;
 	/**
 	 * Add own number from carrier
 	 * @method
@@ -124,7 +124,7 @@ export class NumberInterface extends PlivoResourceInterface {
 	 * @promise {@link PhoneNumberInterface} return PhoneNumbers Object if success
 	 * @fail {Error} return Error
 	 */
-	search(countryISO: string, optionalParams: object): Promise < SearchNumberResponse > ;
+	search(countryISO: string, optionalParams: object): Promise < SearchNumberResponse[] > ;
 	/**
 	 * Update Number
 	 * @method


### PR DESCRIPTION
Hello! 

We're in the process of upgrading our version of `plivo-node` ahead of the January 31st deprecation.

We use typescript and noticed that the typescript signatures don't appear to match the underlying API.

The numbers `search` endpoint appears to have a bug.

The numbers `buy` and `update` endpoints appear to make the `appId` a required parameter when it's not strictly required by the API (we tested it without and it work fine). If `appId` is required, it means that you cannot prepurchase numbers.

Let me know if you have any questions? Thanks!!