### PR TITLE
error.response is undefined

### DIFF
--- a/lib/rest/axios.js
+++ b/lib/rest/axios.js
@@ -21,7 +21,7 @@ export function Axios(config) {
     let counter = 0;
     axios.interceptors.response.use(null, (error) => {
       const config = error.config;
-      if (counter < max_time && error.response.status >= 500) {
+      if (counter < max_time && error.response && error.response.status >= 500) {
         counter++;
         config.url = options.urls[counter] + options.authId + '/' + options.action;
         return new Promise((resolve) => {


### PR DESCRIPTION
Sometimes error.response is undefined and error.response.status fails: TypeError: Cannot read properties of undefined (reading 'status')
    at /home/build/plivo/node_modules/plivo/dist/rest/axios.js:47:48
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
Tested in version: ^4.26.1