### PR TITLE
Update axios.js

### DIFF
--- a/lib/rest/axios.js
+++ b/lib/rest/axios.js
@@ -21,7 +21,7 @@ export function Axios(config) {
     let counter = 0;
     axios.interceptors.response.use(null, (error) => {
       const config = error.config;
-      if (counter < max_time && error.response.status >= 500) {
+      if (counter < max_time &&  error.response && error.response.status >= 500) {
         counter++;
         config.url = options.urls[counter] + options.authId + '/' + options.action;
         return new Promise((resolve) => {


### PR DESCRIPTION
Sometimes error.response is undefined (or not an object) therefore the code breaks trying to access the "status" property, throwing an error in our application and polluting the monitoring.