### PR TITLE
fix: correct typing for transfer method in CallInterface

### DIFF
--- a/types/resources/call.d.ts
+++ b/types/resources/call.d.ts
@@ -340,12 +340,20 @@ export class CallInterface extends PlivoResourceInterface {
 	 * @fail {Error} returns Error
 	 */
 	transfer(callUUID: string, params: {
-		legs: string;
+		legs: "both";
 		alegUrl: string;
-		alegMethod: string;
+		alegMethod?: string;
 		blegUrl: string;
-		blegMethod: string;
-	}): Promise < any > ;
+		blegMethod?: string;
+	} | {
+        legs: "aleg";
+        alegUrl: string;
+		alegMethod?: string;
+    } | {
+        legs: "bleg";
+        blegUrl: string;
+        blegMethod?: string;
+    }): Promise < any > ;
 
     /**
      * Start a Stream over a Call


### PR DESCRIPTION
The types of `transfer` are incorrect.

According to the docs (and the JSDocs), the methods properties should be optional, and `belUrl` is required only when `legs: "bleg"`. Currently, this is the only workaround for that:

```typescript
client.calls.transfer(payload.CallUUID, {
    legs: "aleg",
    alegMethod: "POST",
    alegUrl: url.toString(),

    // optional props, bad typings.
    blegMethod: undefined as unknown as string,
    blegUrl: undefined as unknown as string
});
```