### PR TITLE
Add bulk_messages.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change Log
+## [4.78.0](https://github.com/plivo/plivo-node/tree/v4.78.0) (2026-05-23)
+**Major - bulk_messages.create**
+- Added `src`, `dst`, `text`, `type`, `url`, `method`, `log`, `powerpack_uuid` parameters to bulk_messages.create (POST /v1/Account/{auth_id}/Message/Bulk/)
+
+_Source: plivo/api-messaging#9001_
+
 ## [v4.77.0](https://github.com/plivo/plivo-node/tree/v4.77.0) (2026-05-05)
 **Feature - Account Phone Number typed param surface + bug fixes**
 - Extended `numbers.update()` typed surface to cover all documented params: `complianceApplicationId`, `cnam`, `cnamCallbackUrl`, `cnamCallbackMethod`, `callerReputation`, `profileUuid`, `callerReputationCallbackUrl`, `callerReputationCallbackMethod` (in addition to existing `appId`, `subAccount`, `alias`, `cnamLookup`)

--- a/examples/bulkMessages/sendBulkMessage.js
+++ b/examples/bulkMessages/sendBulkMessage.js
@@ -1,0 +1,22 @@
+import plivo from '../../lib/plivo.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.bulkMessages
+    .create(
+        '14155551234',
+        ['14155559001', '14155559002', '14155559003'],
+        'Hello from Plivo bulk messaging!',
+        {
+            type: 'sms',
+            url: 'https://example.com/delivery-callback',
+            method: 'POST',
+            log: false
+        }
+    )
+    .then(response => {
+        console.log(response);
+    })
+    .catch(error => {
+        console.error(error);
+    });

--- a/lib/resources/bulkMessages.js
+++ b/lib/resources/bulkMessages.js
@@ -1,0 +1,139 @@
+import * as _ from "lodash";
+
+import {
+    PlivoResource,
+    PlivoResourceInterface
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'Message/Bulk/';
+const idField = 'messageUuid';
+let actionKey = Symbol('api action');
+let klassKey = Symbol('constructor');
+let idKey = Symbol('id filed');
+let clientKey = Symbol('make api call');
+
+export class BulkMessageResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.messageUuid = params.messageUuid;
+        this.message = params.message;
+        if (params.invalidNumber !== undefined) {
+            this.invalidNumber = params.invalidNumber;
+        }
+    }
+}
+
+/**
+ * Represents a BulkMessage
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class BulkMessage extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, BulkMessage, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+
+        if (idField in data) {
+            this.id = data[idField];
+        }
+
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents a BulkMessage Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class BulkMessageInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, BulkMessage, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[klassKey] = BulkMessage;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Send a bulk SMS message to up to 1000 destinations in one API call.
+     * @method
+     * @param {string} src - The source phone number or sender ID.
+     * @param {Array<string>} dst - List of destination phone numbers (1–1000 entries).
+     * @param {string} text - The text content of the message (max 1600 characters).
+     * @param {object} [optionalParams] - Optional parameters.
+     * @param {string} [optionalParams.type] - The type of message (e.g. sms).
+     * @param {string} [optionalParams.url] - Delivery status callback URL.
+     * @param {string} [optionalParams.method] - HTTP method for the callback URL (GET or POST).
+     * @param {boolean} [optionalParams.log] - Whether to log message content; defaults to false.
+     * @param {string} [optionalParams.powerpack_uuid] - UUID of the Powerpack to use.
+     * @promise {object} return {@link BulkMessageResponse} object if success
+     * @fail {Error} return Error
+     */
+    create(src, dst, text, optionalParams) {
+        let errors = validate([
+            {
+                field: 'src',
+                value: src,
+                validators: ['isRequired']
+            },
+            {
+                field: 'dst',
+                value: dst,
+                validators: ['isRequired']
+            },
+            {
+                field: 'text',
+                value: text,
+                validators: ['isRequired']
+            }
+        ]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let params = optionalParams || {};
+
+        params.src = src;
+        params.dst = _.isArray(dst) ? dst : [dst];
+        params.text = text;
+
+        let client = this[clientKey];
+        let idField = this[idKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action, params)
+                .then(response => {
+                    resolve(new BulkMessageResponse(response.body, idField));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Send a bulk SMS message (alias for create).
+     * @method
+     * @param {string} src - The source phone number or sender ID.
+     * @param {Array<string>} dst - List of destination phone numbers (1–1000 entries).
+     * @param {string} text - The text content of the message (max 1600 characters).
+     * @param {object} [optionalParams] - Optional parameters.
+     * @promise {object} return {@link BulkMessageResponse} object if success
+     * @fail {Error} return Error
+     */
+    send(src, dst, text, optionalParams) {
+        return this.create(src, dst, text, optionalParams);
+    }
+}

--- a/lib/tests/bulkMessages.js
+++ b/lib/tests/bulkMessages.js
@@ -1,0 +1,152 @@
+import {
+    assert
+} from 'chai';
+import sinon from 'sinon';
+import {
+    BulkMessageInterface,
+    BulkMessageResponse
+} from '../resources/bulkMessages.js';
+
+let client = function(method, action, params) {
+    return new Promise((resolve, reject) => {
+        resolve({
+            response: {
+                status: 202
+            },
+            body: {
+                apiId: 'api-id-test',
+                messageUuid: ['uuid-1', 'uuid-2'],
+                message: 'messages queued'
+            }
+        });
+    });
+};
+
+describe('BulkMessages', function() {
+    describe('create', function() {
+        it('should create a bulk message successfully', function() {
+            let bulkMessageInterface = new BulkMessageInterface(client);
+            return bulkMessageInterface
+                .create(
+                    '14155551234',
+                    ['14155559001', '14155559002'],
+                    'Hello World'
+                )
+                .then(response => {
+                    assert.instanceOf(response, BulkMessageResponse);
+                    assert.equal(response.apiId, 'api-id-test');
+                    assert.deepEqual(response.messageUuid, ['uuid-1', 'uuid-2']);
+                    assert.equal(response.message, 'messages queued');
+                });
+        });
+
+        it('should create a bulk message with optional params', function() {
+            let bulkMessageInterface = new BulkMessageInterface(client);
+            return bulkMessageInterface
+                .create(
+                    '14155551234',
+                    ['14155559001', '14155559002'],
+                    'Hello World',
+                    {
+                        type: 'sms',
+                        url: 'https://example.com/callback',
+                        method: 'POST',
+                        log: false,
+                        powerpack_uuid: 'test-powerpack-uuid'
+                    }
+                )
+                .then(response => {
+                    assert.instanceOf(response, BulkMessageResponse);
+                    assert.equal(response.apiId, 'api-id-test');
+                });
+        });
+
+        it('should reject when src is missing', function() {
+            let bulkMessageInterface = new BulkMessageInterface(client);
+            let result = bulkMessageInterface.create(
+                null,
+                ['14155559001'],
+                'Hello World'
+            );
+            return result.then(
+                () => {
+                    assert.fail('Expected promise to be rejected');
+                },
+                err => {
+                    assert.ok(err);
+                }
+            );
+        });
+
+        it('should reject when dst is missing', function() {
+            let bulkMessageInterface = new BulkMessageInterface(client);
+            let result = bulkMessageInterface.create(
+                '14155551234',
+                null,
+                'Hello World'
+            );
+            return result.then(
+                () => {
+                    assert.fail('Expected promise to be rejected');
+                },
+                err => {
+                    assert.ok(err);
+                }
+            );
+        });
+
+        it('should reject when text is missing', function() {
+            let bulkMessageInterface = new BulkMessageInterface(client);
+            let result = bulkMessageInterface.create(
+                '14155551234',
+                ['14155559001'],
+                null
+            );
+            return result.then(
+                () => {
+                    assert.fail('Expected promise to be rejected');
+                },
+                err => {
+                    assert.ok(err);
+                }
+            );
+        });
+    });
+
+    describe('send', function() {
+        it('should be an alias for create', function() {
+            let bulkMessageInterface = new BulkMessageInterface(client);
+            return bulkMessageInterface
+                .send(
+                    '14155551234',
+                    ['14155559001', '14155559002'],
+                    'Hello World'
+                )
+                .then(response => {
+                    assert.instanceOf(response, BulkMessageResponse);
+                    assert.equal(response.apiId, 'api-id-test');
+                });
+        });
+    });
+
+    describe('BulkMessageResponse', function() {
+        it('should set invalidNumber when present', function() {
+            let response = new BulkMessageResponse({
+                apiId: 'api-id-test',
+                messageUuid: ['uuid-1'],
+                message: 'messages queued',
+                invalidNumber: ['14155550000']
+            });
+            assert.deepEqual(response.invalidNumber, ['14155550000']);
+        });
+
+        it('should not set invalidNumber when absent', function() {
+            let response = new BulkMessageResponse({
+                apiId: 'api-id-test',
+                messageUuid: ['uuid-1'],
+                message: 'messages queued'
+            });
+            assert.isUndefined(response.invalidNumber);
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.77.0",
+  "version": "4.78.0",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [


### PR DESCRIPTION
# Add bulk_messages.create

Base: master ← rune/pr-9001-bulk_messages-create

Reviewers (picked by recent commit activity):
- @avinashp-plivo (4 commits)
- Koushik SK <koushik.sk@ip-10-10-55-180.ap-south-1.compute.internal> (3 commits)

Adds `bulk_messages.create()` — `POST /v1/Account/{auth_id}/Message/Bulk/`.

Send a single SMS message to up to 1000 destinations in one API call, billed independently per destination.

**Parameters**

- `src` (string, required) — The source phone number or sender ID to send the message from.
- `dst` (array<string>, required) — List of destination phone numbers; minimum 1 and maximum 1000 entries.
- `text` (string, required) — The text content of the message; maximum 1600 characters.
- `type` (string, optional) — The type of message (e.g. sms).
- `url` (string, optional) — The URL to which delivery status callbacks are sent.
- `method` (string, optional) — The HTTP method used to invoke the callback URL (GET or POST).
- `log` (boolean, optional) — Whether to log the message content; defaults to false.
- `powerpack_uuid` (string, optional) — UUID of the Powerpack to use for sending the bulk message.

Each method ships with a unit test, a usage example, a bumped version, and a CHANGELOG entry.
