### PR TITLE
Add whatsapp_templates.create, whatsapp_templates.update, verify_apps.create, verify_apps.list, verify_app_templates.list, verify_apps.get, verify_apps.update, verify_apps.delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Change Log
+## [4.78.0](https://github.com/plivo/plivo-node/tree/v4.78.0) (2026-05-23)
+**Feature - whatsapp_templates, verify_apps, verify_app_templates API updates**
+- Added `application_id` optional parameter to whatsapp_templates.create (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/)
+- Added `application_id` optional parameter to whatsapp_templates.update (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `brand_name`, `sms_channel`, `voice_channel`, `wa_channel`, `is_default`, `template_uuid`, `message_redaction`, `customer_app_hash`, `max_validation_attempts`, `enable_fraudshield`, `fs_protection_level`, `waba_id`, `waba_phone_number`, `waba_template_id` parameters to verify_apps.create (POST /v1/Account/{auth_id}/Verify/App/)
+- Added `name`, `app_uuid`, `channel`, `status`, `limit`, `offset`, `created_at`, `created_at__lt`, `created_at__lte`, `created_at__gt`, `created_at__gte`, `subaccount_auth_id` parameters to verify_apps.list (GET /v1/Account/{auth_id}/Verify/App/)
+- GET /v1/Account/{auth_id}/Verify/App/templates/ — verify_app_templates.list. List available SMS OTP templates for the account including account-owned and Plivo system defaults.
+- GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/ — verify_apps.get. Retrieve details of a specific Verify App by its UUID.
+- Added `name`, `brand_name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `sms_channel`, `voice_channel`, `wa_channel`, `is_default`, `template_uuid`, `message_redaction`, `customer_app_hash`, `max_validation_attempts`, `enable_fraudshield`, `fs_protection_level`, `waba_id`, `waba_phone_number`, `waba_template_id` parameters to verify_apps.update (POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/ — verify_apps.delete. Soft-delete a Verify App by its UUID.
+
+_Source: plivo/api-messaging#629_
+
 ## [v4.77.0](https://github.com/plivo/plivo-node/tree/v4.77.0) (2026-05-05)
 **Feature - Account Phone Number typed param surface + bug fixes**
 - Extended `numbers.update()` typed surface to cover all documented params: `complianceApplicationId`, `cnam`, `cnamCallbackUrl`, `cnamCallbackMethod`, `callerReputation`, `profileUuid`, `callerReputationCallbackUrl`, `callerReputationCallbackMethod` (in addition to existing `appId`, `subAccount`, `alias`, `cnamLookup`)

--- a/examples/verifyAppTemplates/list.js
+++ b/examples/verifyAppTemplates/list.js
@@ -1,0 +1,19 @@
+import plivo from '../../lib/index.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyAppTemplates.list()
+    .then(function (response) {
+        console.log('API ID:', response.apiId);
+        console.log('Templates:');
+        response.templates.forEach(function (template) {
+            console.log('  Template UUID:', template.templateUuid);
+            console.log('  Friendly Name:', template.friendlyName);
+            console.log('  Text:', template.text);
+            console.log('  Locale:', template.locale);
+            console.log('---');
+        });
+    })
+    .catch(function (error) {
+        console.error('Error:', error);
+    });

--- a/examples/verifyApps/create.js
+++ b/examples/verifyApps/create.js
@@ -1,0 +1,23 @@
+import plivo from '../../lib/rest/client.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.create('My OTP App', {
+    otp_length: 6,
+    otp_expiry: 5,
+    otp_attempts: 3,
+    brand_name: 'Acme Corp',
+    sms_channel: true,
+    voice_channel: false,
+    wa_channel: false,
+    is_default: false,
+    message_redaction: false,
+    enable_fraudshield: true,
+    fs_protection_level: 'medium'
+})
+.then(function(response) {
+    console.log(response);
+})
+.catch(function(error) {
+    console.error(error);
+});

--- a/examples/verifyApps/delete.js
+++ b/examples/verifyApps/delete.js
@@ -1,0 +1,11 @@
+import plivo from '../../lib/rest/client.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.delete('<app_uuid>')
+.then(function(response) {
+    console.log(response);
+})
+.catch(function(error) {
+    console.error(error);
+});

--- a/examples/verifyApps/get.js
+++ b/examples/verifyApps/get.js
@@ -1,0 +1,11 @@
+import plivo from '../../lib/rest/client.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.get('<app_uuid>')
+.then(function(response) {
+    console.log(response);
+})
+.catch(function(error) {
+    console.error(error);
+});

--- a/examples/verifyApps/list.js
+++ b/examples/verifyApps/list.js
@@ -1,0 +1,14 @@
+import plivo from '../../lib/rest/client.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.list({
+    limit: 20,
+    offset: 0
+})
+.then(function(response) {
+    console.log(response);
+})
+.catch(function(error) {
+    console.error(error);
+});

--- a/examples/verifyApps/update.js
+++ b/examples/verifyApps/update.js
@@ -1,0 +1,18 @@
+import plivo from '../../lib/rest/client.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.update('<app_uuid>', {
+    name: 'Updated OTP App',
+    brand_name: 'Acme Corp',
+    otp_length: 6,
+    otp_expiry: 10,
+    enable_fraudshield: true,
+    fs_protection_level: 'high'
+})
+.then(function(response) {
+    console.log(response);
+})
+.catch(function(error) {
+    console.error(error);
+});

--- a/examples/whatsappTemplates/createWhatsappTemplate.js
+++ b/examples/whatsappTemplates/createWhatsappTemplate.js
@@ -1,0 +1,16 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.whatsappTemplates.create('YOUR_WABA_ID', {
+    elementName: 'sample_template',
+    languageCode: 'en_US',
+    category: 'UTILITY',
+    applicationId: 'YOUR_APPLICATION_ID'
+})
+.then(function(response) {
+    console.log(response);
+})
+.catch(function(error) {
+    console.error(error);
+});

--- a/examples/whatsappTemplates/updateWhatsappTemplate.js
+++ b/examples/whatsappTemplates/updateWhatsappTemplate.js
@@ -1,0 +1,14 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.whatsappTemplates.update('YOUR_WABA_ID', 'YOUR_TEMPLATE_ID', {
+    category: 'MARKETING',
+    applicationId: 'YOUR_APPLICATION_ID'
+})
+.then(function(response) {
+    console.log(response);
+})
+.catch(function(error) {
+    console.error(error);
+});

--- a/lib/resources/verifyAppTemplates.js
+++ b/lib/resources/verifyAppTemplates.js
@@ -1,0 +1,100 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface,
+    PlivoGenericResponse
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'Verify/App/templates/';
+const idField = 'templateUuid';
+
+let actionKey = Symbol('api action');
+let klassKey = Symbol('constructor');
+let idKey = Symbol('id filed');
+let clientKey = Symbol('make api call');
+
+export class VerifyTemplate {
+    constructor(params) {
+        params = params || {};
+        this.templateUuid = params.templateUuid;
+        this.text = params.text;
+        this.friendlyName = params.friendlyName;
+        this.locale = params.locale;
+    }
+}
+
+export class VerifyAppTemplatesListResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        let templateList = [];
+        if (params.templates && Array.isArray(params.templates)) {
+            params.templates.forEach(item => {
+                templateList.push(new VerifyTemplate(item));
+            });
+        }
+        this.templates = templateList;
+    }
+}
+
+/**
+ * Represents a VerifyAppTemplate
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifyAppTemplate extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, VerifyAppTemplate, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+
+        if (idField in data) {
+            this.id = data[idField];
+        }
+
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents a VerifyAppTemplates Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifyAppTemplateInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, VerifyAppTemplate, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[klassKey] = VerifyAppTemplate;
+        this[idKey] = idField;
+    }
+
+    /**
+     * List available SMS OTP templates for the account including account-owned and Plivo system defaults.
+     * @method
+     * @param {object} [params] - optional query params
+     * @promise {object} return {@link VerifyAppTemplatesListResponse} object if success
+     * @fail {Error} return Error
+     */
+    list(params = {}) {
+        let client = this[clientKey];
+        let act = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', act, params)
+                .then(response => {
+                    resolve(new VerifyAppTemplatesListResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/lib/resources/verifyApps.js
+++ b/lib/resources/verifyApps.js
@@ -1,0 +1,302 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'Verify/App/';
+const idField = 'appUuid';
+let actionKey = Symbol('api action');
+let klassKey = Symbol('constructor');
+let idKey = Symbol('id filed');
+let clientKey = Symbol('make api call');
+
+export class VerifyAppCreateResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.appUuid = params.appUuid;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+export class VerifyAppGetResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.verifyApp = params.verifyApp;
+        this.verifyWhatsapp = params.verifyWhatsapp;
+    }
+}
+
+export class VerifyAppListResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.meta = params.meta;
+        this.verifyApps = params.verifyApps;
+    }
+}
+
+export class VerifyAppUpdateResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.appUuid = params.appUuid;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+export class VerifyAppDeleteResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.appUuid = params.appUuid;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+/**
+ * Represents a VerifyApp
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifyApp extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, VerifyApp, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+        if (idField in data) {
+            this.id = data[idField];
+        }
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents a VerifyApp Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifyAppInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, VerifyApp, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[klassKey] = VerifyApp;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Create a Verify App
+     * @method
+     * @param {string} name - Human-friendly app name (must be non-empty).
+     * @param {object} [params] - Optional parameters
+     * @param {string} [params.otp_type] - Format of the generated OTP: integer or string. Defaults to integer.
+     * @param {integer} [params.otp_length] - Number of digits/characters in the OTP. Allowed range: 4–8. Defaults to 6.
+     * @param {integer} [params.otp_expiry] - OTP validity duration in minutes. Allowed range: 1–15. Defaults to 3.
+     * @param {integer} [params.otp_attempts] - Number of attempts allowed for the recipient. Allowed range: 3–10. Defaults to 3.
+     * @param {string} [params.brand_name] - Brand name interpolated into template variables.
+     * @param {boolean} [params.sms_channel] - Enable SMS as a delivery channel. Defaults to true.
+     * @param {boolean} [params.voice_channel] - Enable voice-call as a delivery channel. Defaults to false.
+     * @param {boolean} [params.wa_channel] - Enable WhatsApp as a delivery channel. Defaults to false.
+     * @param {boolean} [params.is_default] - Mark this app as the account's default Verify App. Defaults to false.
+     * @param {string} [params.template_uuid] - UUID of the SMS OTP template to bind to this app.
+     * @param {boolean} [params.message_redaction] - When true, the OTP value is redacted from Plivo's internal logs. Defaults to false.
+     * @param {string} [params.customer_app_hash] - 11-character Android app hash for the SMS Retriever API.
+     * @param {integer} [params.max_validation_attempts] - Number of validation attempts allowed per session. Allowed range: 1–10. Defaults to 5.
+     * @param {boolean} [params.enable_fraudshield] - Enable Plivo FraudShield protection. Defaults to true.
+     * @param {string} [params.fs_protection_level] - FraudShield protection level: low, medium, or high. Defaults to medium.
+     * @param {string} [params.waba_id] - Required when wa_channel is true. The WhatsApp Business Account ID.
+     * @param {string} [params.waba_phone_number] - Required when wa_channel is true. The WhatsApp-registered sender number (E.164).
+     * @param {string} [params.waba_template_id] - Required when wa_channel is true. The Meta WhatsApp template ID.
+     * @promise {object} return {@link VerifyAppCreateResponse} object if success
+     * @fail {Error} return Error
+     */
+    create(name, params = {}) {
+        let errors = validate([{
+            field: 'name',
+            value: name,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        params.name = name;
+
+        let client = this[clientKey];
+        let idField = this[idKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action, params)
+                .then(response => {
+                    resolve(new VerifyAppCreateResponse(response.body, idField));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * List Verify Apps
+     * @method
+     * @param {object} [params] - Optional filter parameters
+     * @param {string} [params.name] - Filter by app name (substring match, case-insensitive).
+     * @param {string} [params.app_uuid] - Filter by app UUID.
+     * @param {string} [params.channel] - Filter to apps with given channel(s) enabled: sms, voice, sms&voice, or voice&sms.
+     * @param {string} [params.status] - Filter by app status: active or deleted.
+     * @param {integer} [params.limit] - Maximum number of results to return. Defaults to 20.
+     * @param {integer} [params.offset] - Number of results to skip. Defaults to 0.
+     * @param {string} [params.created_at] - Filter to apps created at exactly this timestamp.
+     * @param {string} [params.created_at__lt] - Filter to apps created before this timestamp.
+     * @param {string} [params.created_at__lte] - Filter to apps created at or before this timestamp.
+     * @param {string} [params.created_at__gt] - Filter to apps created after this timestamp.
+     * @param {string} [params.created_at__gte] - Filter to apps created at or after this timestamp.
+     * @param {string} [params.subaccount_auth_id] - Filter to apps owned by the given subaccount.
+     * @promise {object} return {@link VerifyAppListResponse} object if success
+     * @fail {Error} return Error
+     */
+    list(params = {}) {
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action, params)
+                .then(response => {
+                    resolve(new VerifyAppListResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Get a Verify App by UUID
+     * @method
+     * @param {string} appUuid - UUID of the Verify App to retrieve.
+     * @promise {object} return {@link VerifyAppGetResponse} object if success
+     * @fail {Error} return Error
+     */
+    get(appUuid) {
+        let errors = validate([{
+            field: 'appUuid',
+            value: appUuid,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action + appUuid + '/')
+                .then(response => {
+                    resolve(new VerifyAppGetResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Update a Verify App
+     * @method
+     * @param {string} appUuid - UUID of the Verify App to update.
+     * @param {object} [params] - Fields to update (only included fields are modified)
+     * @param {string} [params.name] - Updated app name.
+     * @param {string} [params.brand_name] - Updated brand name.
+     * @param {string} [params.otp_type] - Updated OTP type: integer or string.
+     * @param {integer} [params.otp_length] - Updated OTP length (4–8).
+     * @param {integer} [params.otp_expiry] - Updated OTP expiry in minutes (1–15).
+     * @param {integer} [params.otp_attempts] - Updated number of OTP attempts (3–10).
+     * @param {boolean} [params.sms_channel] - Enable or disable SMS channel.
+     * @param {boolean} [params.voice_channel] - Enable or disable voice channel.
+     * @param {boolean} [params.wa_channel] - Enable or disable WhatsApp channel.
+     * @param {boolean} [params.is_default] - Mark or unmark as account default app.
+     * @param {string} [params.template_uuid] - Updated SMS OTP template UUID.
+     * @param {boolean} [params.message_redaction] - Enable or disable OTP redaction from logs.
+     * @param {string} [params.customer_app_hash] - Updated Android app hash (≤11 characters).
+     * @param {integer} [params.max_validation_attempts] - Updated max validation attempts per session (1–10).
+     * @param {boolean} [params.enable_fraudshield] - Enable or disable FraudShield protection.
+     * @param {string} [params.fs_protection_level] - Updated FraudShield protection level: low, medium, or high.
+     * @param {string} [params.waba_id] - Updated WhatsApp Business Account ID.
+     * @param {string} [params.waba_phone_number] - Updated WhatsApp-registered sender number.
+     * @param {string} [params.waba_template_id] - Updated Meta WhatsApp template ID.
+     * @promise {object} return {@link VerifyAppUpdateResponse} object if success
+     * @fail {Error} return Error
+     */
+    update(appUuid, params = {}) {
+        let errors = validate([{
+            field: 'appUuid',
+            value: appUuid,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action + appUuid + '/', params)
+                .then(response => {
+                    resolve(new VerifyAppUpdateResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Delete a Verify App
+     * @method
+     * @param {string} appUuid - UUID of the Verify App to delete.
+     * @promise {object} return {@link VerifyAppDeleteResponse} object if success
+     * @fail {Error} return Error
+     */
+    delete(appUuid) {
+        let errors = validate([{
+            field: 'appUuid',
+            value: appUuid,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('DELETE', action + appUuid + '/')
+                .then(response => {
+                    resolve(new VerifyAppDeleteResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/lib/resources/whatsappTemplates.js
+++ b/lib/resources/whatsappTemplates.js
@@ -1,0 +1,245 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface,
+    PlivoGenericResponse
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'WhatsApp/Template/';
+const idField = 'templateId';
+const clientKey = Symbol('make api call');
+const actionKey = Symbol('api action');
+const idKey = Symbol('id field');
+
+export class WhatsAppTemplateResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.message = params.message;
+        this.templateId = params.templateId;
+    }
+}
+
+/**
+ * Represents a WhatsApp Template
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class WhatsAppTemplate extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, WhatsAppTemplate, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+
+        if (idField in data) {
+            this.id = data[idField];
+        }
+
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents a WhatsApp Template Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class WhatsAppTemplateInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, WhatsAppTemplate, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Create a WhatsApp Template
+     * @method
+     * @param {string} wabaId - WABA ID associated with the template
+     * @param {object} params - parameters for creating the template
+     * @param {string} [params.applicationId] - Optional application ID associated with the WhatsApp template
+     * @promise {object} return {@link WhatsAppTemplateResponse} object if success
+     * @fail {Error} return Error
+     */
+    create(wabaId, params = {}) {
+        let errors = validate([{
+            field: 'wabaId',
+            value: wabaId,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let requestParams = Object.assign({}, params);
+
+        if (requestParams.applicationId !== undefined) {
+            requestParams.application_id = requestParams.applicationId;
+            delete requestParams.applicationId;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action + wabaId + '/', requestParams)
+                .then(response => {
+                    resolve(new WhatsAppTemplateResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Update a WhatsApp Template
+     * @method
+     * @param {string} wabaId - WABA ID associated with the template
+     * @param {string} templateId - ID of the template to update
+     * @param {object} params - parameters for updating the template
+     * @param {string} [params.applicationId] - Optional application ID associated with the WhatsApp template
+     * @promise {object} return {@link WhatsAppTemplateResponse} object if success
+     * @fail {Error} return Error
+     */
+    update(wabaId, templateId, params = {}) {
+        let errors = validate([{
+            field: 'wabaId',
+            value: wabaId,
+            validators: ['isRequired']
+        }, {
+            field: 'templateId',
+            value: templateId,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let requestParams = Object.assign({}, params);
+
+        if (requestParams.applicationId !== undefined) {
+            requestParams.application_id = requestParams.applicationId;
+            delete requestParams.applicationId;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action + wabaId + '/' + templateId + '/', requestParams)
+                .then(response => {
+                    resolve(new WhatsAppTemplateResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Get a WhatsApp Template by WABA ID
+     * @method
+     * @param {string} wabaId - WABA ID associated with the template
+     * @promise {object} return {@link WhatsAppTemplate} object if success
+     * @fail {Error} return Error
+     */
+    get(wabaId) {
+        let errors = validate([{
+            field: 'wabaId',
+            value: wabaId,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action + wabaId + '/')
+                .then(response => {
+                    resolve(new WhatsAppTemplate(client, response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * List WhatsApp Templates
+     * @method
+     * @param {object} [params] - optional filter parameters
+     * @promise {object[]} return list of {@link WhatsAppTemplate} objects if success
+     * @fail {Error} return Error
+     */
+    list(params = {}) {
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action, params)
+                .then(response => {
+                    let objects = [];
+                    Object.defineProperty(objects, 'meta', {
+                        value: response.body.meta,
+                        enumerable: true
+                    });
+                    Object.defineProperty(objects, 'apiId', {
+                        value: response.body.apiId,
+                        enumerable: true
+                    });
+                    (response.body.objects || []).forEach(item => {
+                        objects.push(new WhatsAppTemplate(client, item));
+                    });
+                    resolve(objects);
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Delete a WhatsApp Template
+     * @method
+     * @param {string} wabaId - WABA ID associated with the template
+     * @param {string} templateId - ID of the template to delete
+     * @promise {boolean} return true if success
+     * @fail {Error} return Error
+     */
+    delete(wabaId, templateId) {
+        let errors = validate([{
+            field: 'wabaId',
+            value: wabaId,
+            validators: ['isRequired']
+        }, {
+            field: 'templateId',
+            value: templateId,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('DELETE', action + wabaId + '/' + templateId + '/')
+                .then(() => {
+                    resolve(true);
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.77.0",
+  "version": "4.78.0",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/tests/resources/verifyAppTemplates.js
+++ b/tests/resources/verifyAppTemplates.js
@@ -1,0 +1,94 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { VerifyAppTemplateInterface, VerifyAppTemplatesListResponse, VerifyTemplate } from '../../lib/resources/verifyAppTemplates.js';
+
+describe('VerifyAppTemplates', function () {
+    describe('list', function () {
+        it('should return a VerifyAppTemplatesListResponse on success', function () {
+            let mockResponse = {
+                body: {
+                    apiId: 'test-api-id',
+                    templates: [
+                        {
+                            templateUuid: 'tmpl-uuid-1',
+                            text: 'Your OTP is {{otp}}',
+                            friendlyName: 'Default OTP Template',
+                            locale: 'en'
+                        },
+                        {
+                            templateUuid: 'tmpl-uuid-2',
+                            text: 'Ihr Code ist {{otp}}',
+                            friendlyName: 'German OTP Template',
+                            locale: 'de'
+                        }
+                    ]
+                }
+            };
+
+            let client = sinon.stub().resolves(mockResponse);
+            let iface = new VerifyAppTemplateInterface(client);
+
+            return iface.list().then(response => {
+                assert(client.calledOnce);
+                assert.equal(client.args[0][0], 'GET');
+                assert.equal(client.args[0][1], 'Verify/App/templates/');
+                assert(response instanceof VerifyAppTemplatesListResponse);
+                assert.equal(response.apiId, 'test-api-id');
+                assert.equal(response.templates.length, 2);
+                assert(response.templates[0] instanceof VerifyTemplate);
+                assert.equal(response.templates[0].templateUuid, 'tmpl-uuid-1');
+                assert.equal(response.templates[0].text, 'Your OTP is {{otp}}');
+                assert.equal(response.templates[0].friendlyName, 'Default OTP Template');
+                assert.equal(response.templates[0].locale, 'en');
+                assert.equal(response.templates[1].templateUuid, 'tmpl-uuid-2');
+                assert.equal(response.templates[1].locale, 'de');
+            });
+        });
+
+        it('should handle empty templates array', function () {
+            let mockResponse = {
+                body: {
+                    apiId: 'test-api-id-empty',
+                    templates: []
+                }
+            };
+
+            let client = sinon.stub().resolves(mockResponse);
+            let iface = new VerifyAppTemplateInterface(client);
+
+            return iface.list().then(response => {
+                assert(response instanceof VerifyAppTemplatesListResponse);
+                assert.equal(response.apiId, 'test-api-id-empty');
+                assert.equal(response.templates.length, 0);
+            });
+        });
+
+        it('should reject on client error', function () {
+            let client = sinon.stub().rejects(new Error('Network error'));
+            let iface = new VerifyAppTemplateInterface(client);
+
+            return iface.list().then(() => {
+                assert.fail('Expected rejection');
+            }).catch(error => {
+                assert.equal(error.message, 'Network error');
+            });
+        });
+
+        it('should pass optional params to client', function () {
+            let mockResponse = {
+                body: {
+                    apiId: 'test-api-id',
+                    templates: []
+                }
+            };
+
+            let client = sinon.stub().resolves(mockResponse);
+            let iface = new VerifyAppTemplateInterface(client);
+            let params = { locale: 'en' };
+
+            return iface.list(params).then(() => {
+                assert.deepEqual(client.args[0][2], { locale: 'en' });
+            });
+        });
+    });
+});

--- a/tests/resources/verifyApps.js
+++ b/tests/resources/verifyApps.js
@@ -1,0 +1,205 @@
+import {
+    assert
+} from 'chai';
+import sinon from 'sinon';
+import {
+    VerifyAppInterface,
+    VerifyAppCreateResponse,
+    VerifyAppGetResponse,
+    VerifyAppListResponse,
+    VerifyAppUpdateResponse,
+    VerifyAppDeleteResponse
+} from '../../lib/resources/verifyApps.js';
+
+let client = function() {};
+
+describe('VerifyApps', function() {
+
+    describe('create', function() {
+        it('should create a verify app successfully', function() {
+            let stub = sinon.stub().resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    appUuid: 'test-app-uuid',
+                    message: 'Verify app created successfully'
+                }
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            return verifyApps.create('My OTP App', {
+                otp_length: 6,
+                sms_channel: true
+            }).then(function(response) {
+                assert.instanceOf(response, VerifyAppCreateResponse);
+                assert.equal(response.apiId, 'test-api-id');
+                assert.equal(response.appUuid, 'test-app-uuid');
+                assert.equal(response.message, 'Verify app created successfully');
+            });
+        });
+
+        it('should return error when name is missing', function() {
+            let stub = sinon.stub().resolves({
+                body: {}
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            let result = verifyApps.create(undefined);
+            assert.instanceOf(result, Promise);
+            return result.catch(function(err) {
+                assert.isDefined(err);
+            });
+        });
+    });
+
+    describe('list', function() {
+        it('should list verify apps successfully', function() {
+            let stub = sinon.stub().resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    meta: {
+                        limit: 20,
+                        offset: 0,
+                        totalCount: 1,
+                        next: null,
+                        previous: null
+                    },
+                    verifyApps: [
+                        {
+                            appUuid: 'test-app-uuid',
+                            name: 'My OTP App'
+                        }
+                    ]
+                }
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            return verifyApps.list({ limit: 20, offset: 0 }).then(function(response) {
+                assert.instanceOf(response, VerifyAppListResponse);
+                assert.equal(response.apiId, 'test-api-id');
+                assert.isArray(response.verifyApps);
+            });
+        });
+    });
+
+    describe('get', function() {
+        it('should get a verify app successfully', function() {
+            let stub = sinon.stub().resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    verifyApp: {
+                        appUuid: 'test-app-uuid',
+                        name: 'My OTP App'
+                    },
+                    verifyWhatsapp: null
+                }
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            return verifyApps.get('test-app-uuid').then(function(response) {
+                assert.instanceOf(response, VerifyAppGetResponse);
+                assert.equal(response.apiId, 'test-api-id');
+                assert.isObject(response.verifyApp);
+            });
+        });
+
+        it('should return error when appUuid is missing', function() {
+            let stub = sinon.stub().resolves({
+                body: {}
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            let result = verifyApps.get(undefined);
+            assert.instanceOf(result, Promise);
+            return result.catch(function(err) {
+                assert.isDefined(err);
+            });
+        });
+    });
+
+    describe('update', function() {
+        it('should update a verify app successfully', function() {
+            let stub = sinon.stub().resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    appUuid: 'test-app-uuid',
+                    message: 'Verify app updated successfully'
+                }
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            return verifyApps.update('test-app-uuid', {
+                name: 'Updated OTP App',
+                otp_length: 8
+            }).then(function(response) {
+                assert.instanceOf(response, VerifyAppUpdateResponse);
+                assert.equal(response.apiId, 'test-api-id');
+                assert.equal(response.appUuid, 'test-app-uuid');
+                assert.equal(response.message, 'Verify app updated successfully');
+            });
+        });
+
+        it('should return error when appUuid is missing', function() {
+            let stub = sinon.stub().resolves({
+                body: {}
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            let result = verifyApps.update(undefined, {});
+            assert.instanceOf(result, Promise);
+            return result.catch(function(err) {
+                assert.isDefined(err);
+            });
+        });
+    });
+
+    describe('delete', function() {
+        it('should delete a verify app successfully', function() {
+            let stub = sinon.stub().resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    appUuid: 'test-app-uuid',
+                    message: 'Verify app deleted successfully'
+                }
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            return verifyApps.delete('test-app-uuid').then(function(response) {
+                assert.instanceOf(response, VerifyAppDeleteResponse);
+                assert.equal(response.apiId, 'test-api-id');
+                assert.equal(response.appUuid, 'test-app-uuid');
+                assert.equal(response.message, 'Verify app deleted successfully');
+            });
+        });
+
+        it('should return error when appUuid is missing', function() {
+            let stub = sinon.stub().resolves({
+                body: {}
+            });
+
+            client = stub;
+            let verifyApps = new VerifyAppInterface(client);
+
+            let result = verifyApps.delete(undefined);
+            assert.instanceOf(result, Promise);
+            return result.catch(function(err) {
+                assert.isDefined(err);
+            });
+        });
+    });
+});


### PR DESCRIPTION
# Add whatsapp_templates.create, whatsapp_templates.update, verify_apps.create, verify_apps.list, verify_app_templates.list, verify_apps.get, verify_apps.update, verify_apps.delete

Base: master ← rune/pr-629-sdk-updates

Reviewers (picked by recent commit activity):
- @avinashp-plivo (4 commits)
- Koushik SK <koushik.sk@ip-10-10-55-180.ap-south-1.compute.internal> (3 commits)

Adds the following methods:

- `whatsapp_templates.create()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/` — Add optional application_id field to the WhatsApp template create request.
- `whatsapp_templates.update()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Add optional application_id field to the WhatsApp template update request.
- `verify_apps.create()` — `POST /v1/Account/{auth_id}/Verify/App/` — Create a new Verify App for OTP delivery with optional channel and configuration settings.
- `verify_apps.list()` — `GET /v1/Account/{auth_id}/Verify/App/` — List Verify Apps owned by the account with optional filtering and pagination.
- `verify_app_templates.list()` — `GET /v1/Account/{auth_id}/Verify/App/templates/` — List available SMS OTP templates for the account including account-owned and Plivo system defaults.
- `verify_apps.get()` — `GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Retrieve details of a specific Verify App by its UUID.
- `verify_apps.update()` — `POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Partially update a Verify App; only fields included in the request body are modified.
- `verify_apps.delete()` — `DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Soft-delete a Verify App by its UUID.

Each method ships with a unit test, a usage example, a bumped version, and a CHANGELOG entry.
