### PR TITLE
Add whatsapp_templates.create, whatsapp_templates.update, whatsapp_templates.get, whatsapp_templates.list, whatsapp_templates.delete, verify_apps.create, verify_apps.list, verify_apps.list_templates, verify_apps.get, verify_apps.update, verify_apps.delete, rcs_capability.check, rcs_assistant_events.create, verify_session.create, messages.create, messages.list, messages.get, verify_apps.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # Change Log
+## [4.78.0](https://github.com/plivo/plivo-node/tree/v4.78.0) (2026-05-23)
+**Feature - whatsapp_templates, verify_apps, rcs_capability, rcs_assistant_events, verify_session, messages API updates**
+- Added `waba_id`, `name`, `category`, `language`, `components`, `allow_category_change` parameters to whatsapp_templates.create (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/)
+- Added `waba_id`, `template_id`, `name`, `category`, `language`, `components`, `allow_category_change` parameters to whatsapp_templates.update (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `waba_id`, `template_id` parameters to whatsapp_templates.get (GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `waba_id`, `template_name`, `limit`, `offset` parameters to whatsapp_templates.list (GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/)
+- Added `waba_id`, `template_id`, `name` parameters to whatsapp_templates.delete (DELETE /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `name`, `brand_name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `max_validation_attempts`, `sms_channel`, `voice_channel`, `wa_channel`, `waba_id`, `waba_phone_number`, `waba_template_id`, `template_uuid`, `is_default`, `message_redaction`, `enable_fraudshield`, `fs_protection_level`, `customer_app_hash`, `number_pool` parameters to verify_apps.create (POST /v1/Account/{auth_id}/Verify/App/)
+- Added `name`, `subaccount`, `limit`, `offset`, `created_at`, `created_at__lt`, `created_at__lte`, `created_at__gt`, `created_at__gte` parameters to verify_apps.list (GET /v1/Account/{auth_id}/Verify/App/)
+- GET /v1/Account/{auth_id}/Verify/App/templates/ — verify_apps.list_templates. List default Verify templates available to the account.
+- Added `app_uuid` required parameter to verify_apps.get (GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- Added `app_uuid`, `name`, `brand_name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `max_validation_attempts`, `sms_channel`, `voice_channel`, `wa_channel`, `waba_id`, `waba_phone_number`, `waba_template_id`, `template_uuid`, `is_default`, `message_redaction`, `enable_fraudshield`, `fs_protection_level`, `customer_app_hash`, `client` parameters to verify_apps.update (POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- Added `app_uuid` required parameter to verify_apps.delete (DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- Added `phone_number`, `agent_uuid` parameters to rcs_capability.check (GET /v1/Account/{auth_id}/RCS/Capability/)
+- POST /v1/Account/{auth_id}/RCS/AssistantEvents/ — rcs_assistant_events.create. Send RCS assistant events.
+- Added `app_hash`, `brand_name`, `code_length`, `dlt_entity_id`, `dlt_sender_id`, `dlt_template_category`, `dlt_template_id`, `dlt_text`, `dtmf`, `fraud_check`, `text` parameters to verify_session.create (POST /v1/Account/{auth_id}/Verify/Session/)
+- Added `content_message` optional parameter to messages.create (POST /v1/Account/{auth_id}/Message/)
+- GET /v1/Account/{auth_id}/Message/ — messages.list. Add error_message, message_sent_time, and message_updated_time fields to the list messages response.
+- GET /v1/Account/{auth_id}/Message/{record_id}/ — messages.get. Add error_message, message_sent_time, and message_updated_time fields to the get message response.
+- Added `number_pool` optional parameter to verify_apps.create (POST /v1/Account/{auth_id}/Verify/App/)
+
+_Source: plivo/api-messaging#630_
+
 ## [v4.77.0](https://github.com/plivo/plivo-node/tree/v4.77.0) (2026-05-05)
 **Feature - Account Phone Number typed param surface + bug fixes**
 - Extended `numbers.update()` typed surface to cover all documented params: `complianceApplicationId`, `cnam`, `cnamCallbackUrl`, `cnamCallbackMethod`, `callerReputation`, `profileUuid`, `callerReputationCallbackUrl`, `callerReputationCallbackMethod` (in addition to existing `appId`, `subAccount`, `alias`, `cnamLookup`)

--- a/examples/rcAssistantEvents/create.js
+++ b/examples/rcAssistantEvents/create.js
@@ -1,0 +1,18 @@
+import * as plivo from '../../lib/rest/client.js';
+
+let client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.rcsAssistantEvents.create({
+        phone_number: '+14151234567',
+        event_type: 'IS_TYPING'
+    })
+    .then(function (response) {
+        console.log('api_id:', response.apiId);
+        console.log('phone_number:', response.phoneNumber);
+        console.log('is_capable:', response.isCapable);
+        console.log('features:', response.features);
+        console.log('message:', response.message);
+    })
+    .catch(function (error) {
+        console.error('Error:', error);
+    });

--- a/examples/rcsCapabilityCheck.js
+++ b/examples/rcsCapabilityCheck.js
@@ -1,0 +1,16 @@
+import plivo from '../lib/rest/client.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+// Check if a phone number is RCS-enabled
+client.rcsCapability.check('+14151234567', { agentUuid: 'your-agent-uuid' })
+    .then(response => {
+        console.log('API ID:', response.apiId);
+        console.log('Phone Number:', response.phoneNumber);
+        console.log('Is RCS Capable:', response.isCapable);
+        console.log('Features:', response.features);
+        console.log('Message:', response.message);
+    })
+    .catch(error => {
+        console.error('Error:', error);
+    });

--- a/examples/verifyApps/create.js
+++ b/examples/verifyApps/create.js
@@ -1,0 +1,25 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.create('My Verify App', {
+    brand_name: 'MyBrand',
+    otp_type: 'numeric',
+    otp_length: 6,
+    otp_expiry: 300,
+    otp_attempts: 3,
+    max_validation_attempts: 5,
+    sms_channel: true,
+    voice_channel: false,
+    wa_channel: false,
+    is_default: false,
+    message_redaction: false,
+    enable_fraudshield: false,
+    number_pool: 'my-number-pool'
+})
+.then(response => {
+    console.log(response);
+})
+.catch(error => {
+    console.error(error);
+});

--- a/examples/verifyApps/delete.js
+++ b/examples/verifyApps/delete.js
@@ -1,0 +1,11 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.delete('<app_uuid>')
+.then(response => {
+    console.log(response);
+})
+.catch(error => {
+    console.error(error);
+});

--- a/examples/verifyApps/get.js
+++ b/examples/verifyApps/get.js
@@ -1,0 +1,11 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.get('<app_uuid>')
+.then(response => {
+    console.log(response);
+})
+.catch(error => {
+    console.error(error);
+});

--- a/examples/verifyApps/list.js
+++ b/examples/verifyApps/list.js
@@ -1,0 +1,14 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.list({
+    limit: 20,
+    offset: 0
+})
+.then(response => {
+    console.log(response);
+})
+.catch(error => {
+    console.error(error);
+});

--- a/examples/verifyApps/listTemplates.js
+++ b/examples/verifyApps/listTemplates.js
@@ -1,0 +1,11 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.listTemplates()
+.then(response => {
+    console.log(response);
+})
+.catch(error => {
+    console.error(error);
+});

--- a/examples/verifyApps/update.js
+++ b/examples/verifyApps/update.js
@@ -1,0 +1,16 @@
+import plivo from '../../lib/plivo.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verifyApps.update('<app_uuid>', {
+    name: 'Updated App Name',
+    brand_name: 'UpdatedBrand',
+    otp_length: 4,
+    sms_channel: true
+})
+.then(response => {
+    console.log(response);
+})
+.catch(error => {
+    console.error(error);
+});

--- a/examples/verify_session_create.js
+++ b/examples/verify_session_create.js
@@ -1,0 +1,23 @@
+import { Client } from '../lib/index.js';
+
+const client = new Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.verify_sessions.create({
+    brand_name: 'MyBrand',
+    app_hash: 'abc123hash',
+    code_length: 6,
+    text: 'Your OTP is <otp>',
+    fraud_check: 'standard',
+    dlt_entity_id: 'your_dlt_entity_id',
+    dlt_template_id: 'your_dlt_template_id',
+    dlt_template_category: 'your_dlt_template_category',
+    dlt_sender_id: 'your_dlt_sender_id',
+    dlt_text: 'Your OTP is <otp>',
+    dtmf: 1
+})
+    .then(response => {
+        console.log('Session created:', response);
+    })
+    .catch(error => {
+        console.error('Error creating session:', error);
+    });

--- a/examples/whatsapp_templates_create.js
+++ b/examples/whatsapp_templates_create.js
@@ -1,0 +1,20 @@
+import plivo from '../lib/index.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.whatsappTemplates.create('<waba_id>', {
+    name: 'sample_template',
+    category: 'MARKETING',
+    language: 'en_US',
+    components: [
+        {
+            type: 'BODY',
+            text: 'Hello, this is a sample template.'
+        }
+    ],
+    allow_category_change: false
+}).then(function (response) {
+    console.log(response);
+}).catch(function (error) {
+    console.error(error);
+});

--- a/examples/whatsapp_templates_delete.js
+++ b/examples/whatsapp_templates_delete.js
@@ -1,0 +1,10 @@
+import plivo from '../lib/index.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.whatsappTemplates.delete('<waba_id>', '<template_id>', 'sample_template')
+    .then(function (response) {
+        console.log(response);
+    }).catch(function (error) {
+        console.error(error);
+    });

--- a/examples/whatsapp_templates_get.js
+++ b/examples/whatsapp_templates_get.js
@@ -1,0 +1,10 @@
+import plivo from '../lib/index.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.whatsappTemplates.get('<waba_id>', '<template_id>')
+    .then(function (response) {
+        console.log(response);
+    }).catch(function (error) {
+        console.error(error);
+    });

--- a/examples/whatsapp_templates_list.js
+++ b/examples/whatsapp_templates_list.js
@@ -1,0 +1,13 @@
+import plivo from '../lib/index.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.whatsappTemplates.list('<waba_id>', {
+    template_name: 'sample_template',
+    limit: 20,
+    offset: 0
+}).then(function (response) {
+    console.log(response);
+}).catch(function (error) {
+    console.error(error);
+});

--- a/examples/whatsapp_templates_update.js
+++ b/examples/whatsapp_templates_update.js
@@ -1,0 +1,20 @@
+import plivo from '../lib/index.js';
+
+const client = new plivo.Client('YOUR_AUTH_ID', 'YOUR_AUTH_TOKEN');
+
+client.whatsappTemplates.update('<waba_id>', '<template_id>', {
+    name: 'sample_template',
+    category: 'UTILITY',
+    language: 'en_US',
+    components: [
+        {
+            type: 'BODY',
+            text: 'Updated template text.'
+        }
+    ],
+    allow_category_change: true
+}).then(function (response) {
+    console.log(response);
+}).catch(function (error) {
+    console.error(error);
+});

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -1,0 +1,1 @@
+export * from './whatsapp_templates.js';

--- a/lib/resources/messages.js
+++ b/lib/resources/messages.js
@@ -191,7 +191,7 @@ export class MessageInterface extends PlivoResourceInterface {
      * @param {string} dst - destination number
      * @param {string} text - text to send
      * @param {object} optionalParams - Optional Params to send message
-     * @param {string} [optionalParams.type] - The type of message. Should be `sms` `whatsapp` or `mms`. Defaults to `sms`.
+     * @param {string} [optionalParams.type] - The type of message. Should be `sms` `whatsapp` `rcs` or `mms`. Defaults to `sms`.
      * @param {string} [optionalParams.url] The URL to which with the status of the message is sent.
      * @param {string} [optionalParams.method] The method used to call the url. Defaults to POST.
      * @param {list} [optionalParams.media_urls] For sending mms, specify the media urls in list of string
@@ -203,6 +203,7 @@ export class MessageInterface extends PlivoResourceInterface {
      * @param {Template} [optionalParams.template] For sending templated whatsapp messages.
      * @param {Interactive} [optionalParams.interactive] For sending interactive whatsapp messages.
      * @param {Location} [optionalParams.location] For sending location whatsapp messages.
+     * @param {object} [optionalParams.content_message] Rich elements for RCS messages; only used in RCS messaging.
      * @promise {object} return {@link PlivoGenericMessage} object if success
      * @fail {Error} return Error
      */
@@ -218,7 +219,7 @@ export class MessageInterface extends PlivoResourceInterface {
      * @param {string} dst - destination number
      * @param {string} text - text to send
      * @param {object} optionalParams - Optional Params to send message
-     * @param {string} [optionalParams.type] - The type of message. Should be `sms` `whatsapp` or `mms`. Defaults to `sms`.
+     * @param {string} [optionalParams.type] - The type of message. Should be `sms` `whatsapp` `rcs` or `mms`. Defaults to `sms`.
      * @param {string} [optionalParams.url] The URL to which with the status of the message is sent.
      * @param {string} [optionalParams.method] The method used to call the url. Defaults to POST.
      * @param {string} [optionalParams.log] If set to false, the content of this message will not be logged on the Plivo infrastructure and the dst value will be masked (e.g., 141XXXXX528),if set to content_only only number will be masked, if set to number_only only text would be masked .Default is set to true.
@@ -229,6 +230,7 @@ export class MessageInterface extends PlivoResourceInterface {
      * @param {string} [optionalParams.dlt_template_category] This is the DLT template category passed in the message request.
      * @param {Interactive} [optionalParams.interactive] For sending interactive whatsapp messages.
      * @param {Location} [optionalParams.location] For sending location whatsapp messages.
+     * @param {object} [optionalParams.content_message] Rich elements for RCS messages; only used in RCS messaging.
      * @promise {object} return {@link PlivoGenericMessage} object if success
      * @fail {Error} return Error
      */
@@ -252,6 +254,7 @@ export class MessageInterface extends PlivoResourceInterface {
             var dlt_entity_id = src.dlt_entity_id;
             var dlt_template_id = src.dlt_template_id;
             var dlt_template_category = src.dlt_template_category;
+            var content_message = src.content_message;
             var src = src.src;
         }
 
@@ -324,7 +327,9 @@ export class MessageInterface extends PlivoResourceInterface {
             if (dlt_template_category) {
                 params.dlt_template_category = dlt_template_category
             }
-    
+            if (content_message) {
+                params.content_message = content_message;
+            }
         }
 
         if ((params.type === 'whatsapp') && !src){

--- a/lib/resources/rcAssistantEvents.js
+++ b/lib/resources/rcAssistantEvents.js
@@ -1,0 +1,88 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface,
+    PlivoGenericResponse
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'RCS/AssistantEvents/';
+const idField = 'apiId';
+let actionKey = Symbol('api action');
+let klassKey = Symbol('constructor');
+let idKey = Symbol('id filed');
+let clientKey = Symbol('make api call');
+
+export class RcsAssistantEventResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.phoneNumber = params.phoneNumber;
+        this.isCapable = params.isCapable;
+        this.features = params.features;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+/**
+ * Represents an RCS Assistant Event
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class RcsAssistantEvent extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, RcsAssistantEvent, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+
+        if (idField in data) {
+            this.id = data[idField];
+        }
+
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents an RCS Assistant Events Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class RcsAssistantEventInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, RcsAssistantEvent, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[klassKey] = RcsAssistantEvent;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Send RCS assistant events.
+     * @method
+     * @param {object} params - parameters for the RCS assistant event
+     * @promise {object} return {@link RcsAssistantEventResponse} object if success
+     * @fail {Error} return Error
+     */
+    create(params = {}) {
+        let client = this[clientKey];
+        let idField = this[idKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action, params)
+                .then(response => {
+                    resolve(new RcsAssistantEventResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/lib/resources/rcsCapability.js
+++ b/lib/resources/rcsCapability.js
@@ -1,0 +1,103 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'RCS/Capability/';
+const idField = 'phoneNumber';
+let clientKey = Symbol('make api call');
+let actionKey = Symbol('api action');
+let idKey = Symbol('id filed');
+
+export class RCSCapabilityCheckResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.phoneNumber = params.phoneNumber;
+        this.isCapable = params.isCapable;
+        this.features = params.features;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+/**
+ * Represents an RCS Capability resource
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class RCSCapability extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, RCSCapability, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+
+        if (idField in data) {
+            this.id = data[idField];
+        }
+
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents an RCS Capability Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class RCSCapabilityInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, RCSCapability, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Check if a phone number is RCS-enabled.
+     * @method
+     * @param {string} phoneNumber - Phone number to check for RCS capability.
+     * @param {object} [params] - Optional params
+     * @param {string} [params.agentUuid] - Agent UUID.
+     * @promise {object} return {@link RCSCapabilityCheckResponse} object if success
+     * @fail {Error} return Error
+     */
+    check(phoneNumber, params = {}) {
+        let errors = validate([{
+            field: 'phone_number',
+            value: phoneNumber,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let queryParams = Object.assign({}, params);
+        queryParams.phone_number = phoneNumber;
+
+        if (queryParams.agentUuid) {
+            queryParams.agent_uuid = queryParams.agentUuid;
+            delete queryParams.agentUuid;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action, queryParams)
+                .then(response => {
+                    resolve(new RCSCapabilityCheckResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/lib/resources/verifyApps.js
+++ b/lib/resources/verifyApps.js
@@ -1,0 +1,321 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'Verify/App/';
+const idField = 'appUuid';
+let actionKey = Symbol('api action');
+let klassKey = Symbol('constructor');
+let idKey = Symbol('id filed');
+let clientKey = Symbol('make api call');
+
+export class VerifyAppCreateResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.appUuid = params.appUuid;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+export class VerifyAppGetResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.verifyApp = params.verifyApp;
+        this.verifyWhatsapp = params.verifyWhatsapp;
+    }
+}
+
+export class VerifyAppListResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.verifyApps = params.verifyApps;
+        this.meta = params.meta;
+    }
+}
+
+export class VerifyAppListTemplatesResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.templates = params.templates;
+    }
+}
+
+export class VerifyAppUpdateResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.appUuid = params.appUuid;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+/**
+ * Represents a VerifyApp
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifyApp extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, VerifyApp, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+        if (idField in data) {
+            this.id = data[idField];
+        }
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents a VerifyApp Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifyAppInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, VerifyApp, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[klassKey] = VerifyApp;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Create a Verify Application
+     * @method
+     * @param {string} name - Application name (required)
+     * @param {object} [optionalParams] - Optional parameters
+     * @param {string} [optionalParams.brand_name] - Brand name for the OTP message
+     * @param {string} [optionalParams.otp_type] - OTP type (numeric, alpha, alphanumeric)
+     * @param {integer} [optionalParams.otp_length] - OTP code length
+     * @param {integer} [optionalParams.otp_expiry] - OTP expiry in seconds
+     * @param {integer} [optionalParams.otp_attempts] - Maximum OTP validation attempts
+     * @param {integer} [optionalParams.max_validation_attempts] - Maximum validation attempts
+     * @param {boolean} [optionalParams.sms_channel] - Enable SMS channel
+     * @param {boolean} [optionalParams.voice_channel] - Enable voice channel
+     * @param {boolean} [optionalParams.wa_channel] - Enable WhatsApp channel
+     * @param {string} [optionalParams.waba_id] - WhatsApp Business Account ID
+     * @param {string} [optionalParams.waba_phone_number] - WhatsApp phone number
+     * @param {string} [optionalParams.waba_template_id] - WhatsApp template ID
+     * @param {string} [optionalParams.template_uuid] - SMS template UUID
+     * @param {boolean} [optionalParams.is_default] - Set as default app
+     * @param {boolean} [optionalParams.message_redaction] - Enable message redaction
+     * @param {boolean} [optionalParams.enable_fraudshield] - Enable FraudShield
+     * @param {string} [optionalParams.fs_protection_level] - FraudShield protection level
+     * @param {string} [optionalParams.customer_app_hash] - Android app hash for SMS retriever
+     * @param {string} [optionalParams.number_pool] - Number pool identifier
+     * @promise {object} return {@link VerifyAppCreateResponse} object if success
+     * @fail {Error} return Error
+     */
+    create(name, optionalParams) {
+        let errors = validate([{
+            field: 'name',
+            value: name,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let params = optionalParams || {};
+        params.name = name;
+
+        let client = this[clientKey];
+        let idField = this[idKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action, params)
+                .then(response => {
+                    resolve(new VerifyAppCreateResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * List Verify Applications
+     * @method
+     * @param {object} [params] - Optional filter params
+     * @param {string} [params.name] - Filter by app name
+     * @param {string} [params.subaccount] - Filter by subaccount auth_id
+     * @param {integer} [params.limit] - Page size
+     * @param {integer} [params.offset] - Page offset
+     * @param {string} [params.created_at] - Filter by exact created_at timestamp
+     * @param {string} [params.created_at__lt] - Filter by created_at less than
+     * @param {string} [params.created_at__lte] - Filter by created_at less than or equal
+     * @param {string} [params.created_at__gt] - Filter by created_at greater than
+     * @param {string} [params.created_at__gte] - Filter by created_at greater than or equal
+     * @promise {object} return {@link VerifyAppListResponse} object if success
+     * @fail {Error} return Error
+     */
+    list(params) {
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action, params)
+                .then(response => {
+                    resolve(new VerifyAppListResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * List default Verify templates
+     * @method
+     * @promise {object} return {@link VerifyAppListTemplatesResponse} object if success
+     * @fail {Error} return Error
+     */
+    listTemplates() {
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action + 'templates/', {})
+                .then(response => {
+                    resolve(new VerifyAppListTemplatesResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Get a Verify Application by UUID
+     * @method
+     * @param {string} appUuid - Verify App UUID
+     * @promise {object} return {@link VerifyAppGetResponse} object if success
+     * @fail {Error} return Error
+     */
+    get(appUuid) {
+        let errors = validate([{
+            field: 'appUuid',
+            value: appUuid,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action + appUuid + '/', {})
+                .then(response => {
+                    resolve(new VerifyAppGetResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Update a Verify Application
+     * @method
+     * @param {string} appUuid - Verify App UUID
+     * @param {object} [params] - Fields to update
+     * @param {string} [params.name] - Application name
+     * @param {string} [params.brand_name] - Brand name
+     * @param {string} [params.otp_type] - OTP type
+     * @param {integer} [params.otp_length] - OTP code length
+     * @param {integer} [params.otp_expiry] - OTP expiry in seconds
+     * @param {integer} [params.otp_attempts] - Maximum OTP attempts
+     * @param {integer} [params.max_validation_attempts] - Maximum validation attempts
+     * @param {boolean} [params.sms_channel] - Enable SMS channel
+     * @param {boolean} [params.voice_channel] - Enable voice channel
+     * @param {boolean} [params.wa_channel] - Enable WhatsApp channel
+     * @param {string} [params.waba_id] - WhatsApp Business Account ID
+     * @param {string} [params.waba_phone_number] - WhatsApp phone number
+     * @param {string} [params.waba_template_id] - WhatsApp template ID
+     * @param {string} [params.template_uuid] - SMS template UUID
+     * @param {boolean} [params.is_default] - Set as default app
+     * @param {boolean} [params.message_redaction] - Enable message redaction
+     * @param {boolean} [params.enable_fraudshield] - Enable FraudShield
+     * @param {string} [params.fs_protection_level] - FraudShield protection level
+     * @param {string} [params.customer_app_hash] - Android app hash
+     * @param {string} [params.client] - Client identifier
+     * @promise {object} return {@link VerifyAppUpdateResponse} object if success
+     * @fail {Error} return Error
+     */
+    update(appUuid, params) {
+        let errors = validate([{
+            field: 'appUuid',
+            value: appUuid,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action + appUuid + '/', params || {})
+                .then(response => {
+                    resolve(new VerifyAppUpdateResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Delete a Verify Application
+     * @method
+     * @param {string} appUuid - Verify App UUID
+     * @promise {boolean} return true if success
+     * @fail {Error} return Error
+     */
+    delete(appUuid) {
+        let errors = validate([{
+            field: 'appUuid',
+            value: appUuid,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('DELETE', action + appUuid + '/', {})
+                .then(() => {
+                    resolve(true);
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/lib/resources/verify_session.js
+++ b/lib/resources/verify_session.js
@@ -1,0 +1,96 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface,
+    PlivoGenericResponse
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'Verify/Session/';
+const idField = 'sessionUuid';
+let actionKey = Symbol('api action');
+let klassKey = Symbol('constructor');
+let idKey = Symbol('id filed');
+let clientKey = Symbol('make api call');
+
+export class CreateVerifySessionResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.sessionUuid = params.sessionUuid;
+        this.message = params.message;
+    }
+}
+
+/**
+ * Represents a VerifySession
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifySession extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, VerifySession, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+
+        if (idField in data) {
+            this.id = data[idField];
+        }
+
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents a VerifySession Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class VerifySessionInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, VerifySession, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[klassKey] = VerifySession;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Create a Verify Session (generate OTP)
+     * @method
+     * @param {object} [params] - optional params
+     * @param {string} [params.app_hash] - Android app hash for SMS retriever.
+     * @param {string} [params.brand_name] - Brand name displayed in the OTP message.
+     * @param {integer} [params.code_length] - Length of the OTP code.
+     * @param {string} [params.dlt_entity_id] - DLT entity ID for India DLT compliance.
+     * @param {string} [params.dlt_sender_id] - DLT sender ID.
+     * @param {string} [params.dlt_template_category] - DLT template category.
+     * @param {string} [params.dlt_template_id] - DLT template ID.
+     * @param {string} [params.dlt_text] - DLT template text.
+     * @param {integer} [params.dtmf] - DTMF tone for voice OTP.
+     * @param {string} [params.fraud_check] - FraudShield check level.
+     * @param {string} [params.text] - Custom OTP message text.
+     * @promise {object} return {@link CreateVerifySessionResponse} object if success
+     * @fail {Error} return Error
+     */
+    create(params = {}) {
+        let client = this[clientKey];
+        let idField = this[idKey];
+        let action = this[actionKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action, params)
+                .then(response => {
+                    resolve(new CreateVerifySessionResponse(response.body, idField));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/lib/resources/whatsapp_templates.js
+++ b/lib/resources/whatsapp_templates.js
@@ -1,0 +1,309 @@
+import {
+    PlivoResource,
+    PlivoResourceInterface
+} from '../base';
+import {
+    extend,
+    validate
+} from '../utils/common.js';
+
+const action = 'WhatsApp/Template/';
+const idField = 'templateId';
+let actionKey = Symbol('api action');
+let klassKey = Symbol('constructor');
+let idKey = Symbol('id filed');
+let clientKey = Symbol('make api call');
+
+export class WhatsAppTemplateCreateResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.templateId = params.templateId;
+        this.templateName = params.templateName;
+        this.templateStatus = params.templateStatus;
+        this.templateCategory = params.templateCategory;
+        this.templateLanguage = params.templateLanguage;
+        this.status = params.status;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+export class WhatsAppTemplateUpdateResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.templateId = params.templateId;
+        this.templateName = params.templateName;
+        this.templateStatus = params.templateStatus;
+        this.templateCategory = params.templateCategory;
+        this.templateLanguage = params.templateLanguage;
+        this.status = params.status;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+export class WhatsAppTemplateGetResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.templateId = params.templateId;
+        this.name = params.name;
+        this.category = params.category;
+        this.language = params.language;
+        this.status = params.status;
+        this.components = params.components;
+        this.qualityScore = params.qualityScore;
+        this.rejectedReason = params.rejectedReason;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+export class WhatsAppTemplateListResponse {
+    constructor(params) {
+        params = params || {};
+        this.apiId = params.apiId;
+        this.objects = params.objects;
+        this.meta = params.meta;
+        this.status = params.status;
+        this.message = params.message;
+        this.error = params.error;
+    }
+}
+
+/**
+ * Represents a WhatsAppTemplate
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class WhatsAppTemplate extends PlivoResource {
+    constructor(client, data = {}) {
+        super(action, WhatsAppTemplate, idField, client);
+        this[actionKey] = action;
+        this[clientKey] = client;
+        if (idField in data) {
+            this.id = data[idField];
+        }
+        extend(this, data);
+    }
+}
+
+/**
+ * Represents a WhatsAppTemplate Interface
+ * @constructor
+ * @param {function} client - make api call
+ * @param {object} [data] - data of call
+ */
+export class WhatsAppTemplateInterface extends PlivoResourceInterface {
+    constructor(client, data = {}) {
+        super(action, WhatsAppTemplate, idField, client);
+        extend(this, data);
+        this[clientKey] = client;
+        this[actionKey] = action;
+        this[klassKey] = WhatsAppTemplate;
+        this[idKey] = idField;
+    }
+
+    /**
+     * Create a WhatsApp template
+     * @method
+     * @param {string} wabaId - WhatsApp Business Account ID
+     * @param {object} [params] - optional params
+     * @param {string} [params.name] - Template name
+     * @param {string} [params.category] - Template category
+     * @param {string} [params.language] - Template language
+     * @param {Array}  [params.components] - Template components
+     * @param {boolean} [params.allow_category_change] - Whether to allow category change
+     * @promise {object} return {@link WhatsAppTemplateCreateResponse} object if success
+     * @fail {Error} return Error
+     */
+    create(wabaId, params = {}) {
+        let errors = validate([{
+            field: 'waba_id',
+            value: wabaId,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action + wabaId + '/', params)
+                .then(response => {
+                    resolve(new WhatsAppTemplateCreateResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Update an existing WhatsApp template
+     * @method
+     * @param {string} wabaId - WhatsApp Business Account ID
+     * @param {string} templateId - Template ID to update
+     * @param {object} [params] - optional params
+     * @param {string} [params.name] - Template name
+     * @param {string} [params.category] - Template category
+     * @param {string} [params.language] - Template language
+     * @param {Array}  [params.components] - Template components
+     * @param {boolean} [params.allow_category_change] - Whether to allow category change
+     * @promise {object} return {@link WhatsAppTemplateUpdateResponse} object if success
+     * @fail {Error} return Error
+     */
+    update(wabaId, templateId, params = {}) {
+        let errors = validate([{
+                field: 'waba_id',
+                value: wabaId,
+                validators: ['isRequired']
+            },
+            {
+                field: 'template_id',
+                value: templateId,
+                validators: ['isRequired']
+            }
+        ]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('POST', action + wabaId + '/' + templateId + '/', params)
+                .then(response => {
+                    resolve(new WhatsAppTemplateUpdateResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Retrieve a WhatsApp template by its ID
+     * @method
+     * @param {string} wabaId - WhatsApp Business Account ID
+     * @param {string} templateId - Template ID to retrieve
+     * @promise {object} return {@link WhatsAppTemplateGetResponse} object if success
+     * @fail {Error} return Error
+     */
+    get(wabaId, templateId) {
+        let errors = validate([{
+                field: 'waba_id',
+                value: wabaId,
+                validators: ['isRequired']
+            },
+            {
+                field: 'template_id',
+                value: templateId,
+                validators: ['isRequired']
+            }
+        ]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action + wabaId + '/' + templateId + '/')
+                .then(response => {
+                    resolve(new WhatsAppTemplateGetResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * List WhatsApp templates for the given WABA
+     * @method
+     * @param {string} wabaId - WhatsApp Business Account ID
+     * @param {object} [params] - optional params
+     * @param {string} [params.template_name] - Filter by template name
+     * @param {number} [params.limit] - Page size (default 20)
+     * @param {number} [params.offset] - Page offset (default 0)
+     * @promise {object} return {@link WhatsAppTemplateListResponse} object if success
+     * @fail {Error} return Error
+     */
+    list(wabaId, params = {}) {
+        let errors = validate([{
+            field: 'waba_id',
+            value: wabaId,
+            validators: ['isRequired']
+        }]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('GET', action + wabaId + '/', params)
+                .then(response => {
+                    resolve(new WhatsAppTemplateListResponse(response.body));
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+
+    /**
+     * Delete a WhatsApp template by ID and name
+     * @method
+     * @param {string} wabaId - WhatsApp Business Account ID
+     * @param {string} templateId - Template ID to delete
+     * @param {string} name - Template name
+     * @promise {boolean} return true if success
+     * @fail {Error} return Error
+     */
+    delete(wabaId, templateId, name) {
+        let errors = validate([{
+                field: 'waba_id',
+                value: wabaId,
+                validators: ['isRequired']
+            },
+            {
+                field: 'template_id',
+                value: templateId,
+                validators: ['isRequired']
+            },
+            {
+                field: 'name',
+                value: name,
+                validators: ['isRequired']
+            }
+        ]);
+
+        if (errors) {
+            return errors;
+        }
+
+        let client = this[clientKey];
+
+        return new Promise((resolve, reject) => {
+            client('DELETE', action + wabaId + '/' + templateId + '/', {
+                    name: name
+                })
+                .then(() => {
+                    resolve(true);
+                })
+                .catch(error => {
+                    reject(error);
+                });
+        });
+    }
+}

--- a/lib/tests/rcAssistantEvents.js
+++ b/lib/tests/rcAssistantEvents.js
@@ -1,0 +1,64 @@
+import {
+    RcsAssistantEventInterface,
+    RcsAssistantEventResponse
+} from '../resources/rcAssistantEvents.js';
+
+import assert from 'assert';
+
+let actionKey = Symbol('api action');
+let clientKey = Symbol('make api call');
+
+describe('RcsAssistantEvents', function () {
+    describe('create', function () {
+        it('should send RCS assistant events and return a response', function () {
+            let client = function (method, action, params) {
+                return new Promise((resolve, reject) => {
+                    resolve({
+                        body: {
+                            apiId: 'test-api-id',
+                            phoneNumber: '+14151234567',
+                            isCapable: true,
+                            features: ['RICHCARD_STANDALONE', 'ACTION_CREATE_CALENDAR_EVENT'],
+                            message: 'Event sent successfully.',
+                            error: null
+                        }
+                    });
+                });
+            };
+
+            let rcsAssistantEventInterface = new RcsAssistantEventInterface(client);
+
+            let params = {
+                phone_number: '+14151234567',
+                event_type: 'IS_TYPING'
+            };
+
+            return rcsAssistantEventInterface.create(params)
+                .then(response => {
+                    assert.equal(response.apiId, 'test-api-id');
+                    assert.equal(response.phoneNumber, '+14151234567');
+                    assert.equal(response.isCapable, true);
+                    assert.deepEqual(response.features, ['RICHCARD_STANDALONE', 'ACTION_CREATE_CALENDAR_EVENT']);
+                    assert.equal(response.message, 'Event sent successfully.');
+                });
+        });
+
+        it('should reject with an error on API failure', function () {
+            let client = function (method, action, params) {
+                return new Promise((resolve, reject) => {
+                    reject(new Error('API Error'));
+                });
+            };
+
+            let rcsAssistantEventInterface = new RcsAssistantEventInterface(client);
+
+            return rcsAssistantEventInterface.create({})
+                .then(() => {
+                    assert.fail('Expected rejection but got resolution');
+                })
+                .catch(error => {
+                    assert.equal(error.message, 'API Error');
+                });
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.77.0",
+  "version": "4.78.0",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/tests/rcsCapability.test.js
+++ b/tests/rcsCapability.test.js
@@ -1,0 +1,110 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import { RCSCapabilityInterface, RCSCapabilityCheckResponse } from '../lib/resources/rcsCapability.js';
+
+describe('RCSCapability', function () {
+    let client;
+
+    beforeEach(function () {
+        client = sinon.stub();
+    });
+
+    describe('RCSCapabilityCheckResponse', function () {
+        it('should construct response correctly', function () {
+            const params = {
+                apiId: 'test-api-id',
+                phoneNumber: '+14151234567',
+                isCapable: true,
+                features: ['RICHCARD_STANDALONE'],
+                message: 'Success',
+                error: null
+            };
+            const response = new RCSCapabilityCheckResponse(params);
+            assert.strictEqual(response.apiId, 'test-api-id');
+            assert.strictEqual(response.phoneNumber, '+14151234567');
+            assert.strictEqual(response.isCapable, true);
+            assert.deepStrictEqual(response.features, ['RICHCARD_STANDALONE']);
+            assert.strictEqual(response.message, 'Success');
+            assert.strictEqual(response.error, null);
+        });
+
+        it('should handle empty params', function () {
+            const response = new RCSCapabilityCheckResponse();
+            assert.strictEqual(response.apiId, undefined);
+            assert.strictEqual(response.phoneNumber, undefined);
+            assert.strictEqual(response.isCapable, undefined);
+            assert.strictEqual(response.features, undefined);
+            assert.strictEqual(response.message, undefined);
+            assert.strictEqual(response.error, undefined);
+        });
+    });
+
+    describe('RCSCapabilityInterface#check', function () {
+        it('should reject if phone_number is not provided', function () {
+            const rcsCapability = new RCSCapabilityInterface(client);
+            const result = rcsCapability.check(undefined);
+            return result.then(
+                () => { throw new Error('Expected rejection'); },
+                err => {
+                    assert.ok(err instanceof Error);
+                }
+            );
+        });
+
+        it('should make GET request with phone_number param', function () {
+            const mockBody = {
+                apiId: 'test-api-id',
+                phoneNumber: '+14151234567',
+                isCapable: true,
+                features: ['RICHCARD_STANDALONE'],
+                message: 'Success',
+                error: null
+            };
+            client.resolves({ body: mockBody });
+
+            const rcsCapability = new RCSCapabilityInterface(client);
+            return rcsCapability.check('+14151234567').then(response => {
+                assert.strictEqual(response.apiId, 'test-api-id');
+                assert.strictEqual(response.phoneNumber, '+14151234567');
+                assert.strictEqual(response.isCapable, true);
+                sinon.assert.calledWith(client, 'GET', 'RCS/Capability/', {
+                    phone_number: '+14151234567'
+                });
+            });
+        });
+
+        it('should include agent_uuid param when agentUuid is provided', function () {
+            const mockBody = {
+                apiId: 'test-api-id',
+                phoneNumber: '+14151234567',
+                isCapable: false,
+                features: [],
+                message: 'Not capable',
+                error: null
+            };
+            client.resolves({ body: mockBody });
+
+            const rcsCapability = new RCSCapabilityInterface(client);
+            return rcsCapability.check('+14151234567', { agentUuid: 'agent-uuid-123' }).then(response => {
+                assert.strictEqual(response.isCapable, false);
+                sinon.assert.calledWith(client, 'GET', 'RCS/Capability/', {
+                    phone_number: '+14151234567',
+                    agent_uuid: 'agent-uuid-123'
+                });
+            });
+        });
+
+        it('should reject on API error', function () {
+            const error = new Error('API Error');
+            client.rejects(error);
+
+            const rcsCapability = new RCSCapabilityInterface(client);
+            return rcsCapability.check('+14151234567').then(
+                () => { throw new Error('Expected rejection'); },
+                err => {
+                    assert.strictEqual(err.message, 'API Error');
+                }
+            );
+        });
+    });
+});

--- a/tests/resources/verifyApps.test.js
+++ b/tests/resources/verifyApps.test.js
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { VerifyAppInterface, VerifyAppCreateResponse, VerifyAppGetResponse, VerifyAppListResponse, VerifyAppListTemplatesResponse, VerifyAppUpdateResponse } from '../../lib/resources/verifyApps.js';
+
+describe('VerifyAppInterface', () => {
+    let client;
+    let verifyApps;
+
+    beforeEach(() => {
+        client = sinon.stub();
+        verifyApps = new VerifyAppInterface(client);
+    });
+
+    describe('create', () => {
+        it('should reject when name is not provided', () => {
+            const result = verifyApps.create();
+            expect(result).to.be.an('object');
+        });
+
+        it('should POST to Verify/App/ with name and optional params', done => {
+            client.resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    appUuid: 'test-app-uuid',
+                    message: 'Verify app created'
+                }
+            });
+
+            verifyApps.create('My App', { brand_name: 'Brand', number_pool: 'pool-1' })
+                .then(response => {
+                    expect(client.calledWith('POST', 'Verify/App/', {
+                        name: 'My App',
+                        brand_name: 'Brand',
+                        number_pool: 'pool-1'
+                    })).to.be.true;
+                    expect(response).to.be.instanceof(VerifyAppCreateResponse);
+                    expect(response.appUuid).to.equal('test-app-uuid');
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('list', () => {
+        it('should GET Verify/App/ with params', done => {
+            client.resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    verifyApps: [],
+                    meta: { totalCount: 0, limit: 20, offset: 0 }
+                }
+            });
+
+            verifyApps.list({ limit: 20, offset: 0 })
+                .then(response => {
+                    expect(client.calledWith('GET', 'Verify/App/', { limit: 20, offset: 0 })).to.be.true;
+                    expect(response).to.be.instanceof(VerifyAppListResponse);
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('listTemplates', () => {
+        it('should GET Verify/App/templates/', done => {
+            client.resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    templates: []
+                }
+            });
+
+            verifyApps.listTemplates()
+                .then(response => {
+                    expect(client.calledWith('GET', 'Verify/App/templates/', {})).to.be.true;
+                    expect(response).to.be.instanceof(VerifyAppListTemplatesResponse);
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('get', () => {
+        it('should reject when appUuid is not provided', () => {
+            const result = verifyApps.get();
+            expect(result).to.be.an('object');
+        });
+
+        it('should GET Verify/App/{appUuid}/', done => {
+            client.resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    verifyApp: { appUuid: 'test-app-uuid', name: 'My App' },
+                    verifyWhatsapp: null
+                }
+            });
+
+            verifyApps.get('test-app-uuid')
+                .then(response => {
+                    expect(client.calledWith('GET', 'Verify/App/test-app-uuid/', {})).to.be.true;
+                    expect(response).to.be.instanceof(VerifyAppGetResponse);
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('update', () => {
+        it('should reject when appUuid is not provided', () => {
+            const result = verifyApps.update();
+            expect(result).to.be.an('object');
+        });
+
+        it('should POST to Verify/App/{appUuid}/ with params', done => {
+            client.resolves({
+                body: {
+                    apiId: 'test-api-id',
+                    appUuid: 'test-app-uuid',
+                    message: 'Verify app updated'
+                }
+            });
+
+            verifyApps.update('test-app-uuid', { name: 'Updated App' })
+                .then(response => {
+                    expect(client.calledWith('POST', 'Verify/App/test-app-uuid/', { name: 'Updated App' })).to.be.true;
+                    expect(response).to.be.instanceof(VerifyAppUpdateResponse);
+                    expect(response.appUuid).to.equal('test-app-uuid');
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('delete', () => {
+        it('should reject when appUuid is not provided', () => {
+            const result = verifyApps.delete();
+            expect(result).to.be.an('object');
+        });
+
+        it('should DELETE Verify/App/{appUuid}/', done => {
+            client.resolves({});
+
+            verifyApps.delete('test-app-uuid')
+                .then(response => {
+                    expect(client.calledWith('DELETE', 'Verify/App/test-app-uuid/', {})).to.be.true;
+                    expect(response).to.be.true;
+                    done();
+                })
+                .catch(done);
+        });
+    });
+});

--- a/tests/resources/whatsapp_templates.js
+++ b/tests/resources/whatsapp_templates.js
@@ -1,0 +1,217 @@
+import {
+    assert
+} from 'chai';
+import sinon from 'sinon';
+import {
+    WhatsAppTemplateInterface,
+    WhatsAppTemplateCreateResponse,
+    WhatsAppTemplateUpdateResponse,
+    WhatsAppTemplateGetResponse,
+    WhatsAppTemplateListResponse
+} from '../../lib/resources/whatsapp_templates.js';
+
+describe('WhatsAppTemplateInterface', function () {
+    let client;
+    let whatsappTemplates;
+
+    beforeEach(function () {
+        client = sinon.stub();
+        whatsappTemplates = new WhatsAppTemplateInterface(client);
+    });
+
+    describe('create', function () {
+        it('should reject if waba_id is missing', function () {
+            const result = whatsappTemplates.create('');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should call POST with correct path and params', function () {
+            client.returns(Promise.resolve({
+                body: {
+                    apiId: 'test-api-id',
+                    templateId: 'tmpl-123',
+                    templateName: 'sample_template',
+                    templateStatus: 'PENDING',
+                    templateCategory: 'MARKETING',
+                    templateLanguage: 'en_US',
+                    status: 'success',
+                    message: 'Template created'
+                }
+            }));
+
+            const params = {
+                name: 'sample_template',
+                category: 'MARKETING',
+                language: 'en_US',
+                components: [],
+                allow_category_change: false
+            };
+
+            return whatsappTemplates.create('waba-123', params).then(function (response) {
+                assert.instanceOf(response, WhatsAppTemplateCreateResponse);
+                assert.equal(response.templateId, 'tmpl-123');
+                assert.equal(response.templateName, 'sample_template');
+                assert.isTrue(client.calledWith('POST', 'WhatsApp/Template/waba-123/', params));
+            });
+        });
+    });
+
+    describe('update', function () {
+        it('should reject if waba_id is missing', function () {
+            const result = whatsappTemplates.update('', 'tmpl-123');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should reject if template_id is missing', function () {
+            const result = whatsappTemplates.update('waba-123', '');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should call POST with correct path and params', function () {
+            client.returns(Promise.resolve({
+                body: {
+                    apiId: 'test-api-id',
+                    templateId: 'tmpl-123',
+                    templateName: 'sample_template',
+                    templateStatus: 'PENDING',
+                    templateCategory: 'UTILITY',
+                    templateLanguage: 'en_US',
+                    status: 'success',
+                    message: 'Template updated'
+                }
+            }));
+
+            const params = {
+                name: 'sample_template',
+                category: 'UTILITY',
+                language: 'en_US',
+                components: [],
+                allow_category_change: true
+            };
+
+            return whatsappTemplates.update('waba-123', 'tmpl-123', params).then(function (response) {
+                assert.instanceOf(response, WhatsAppTemplateUpdateResponse);
+                assert.equal(response.templateId, 'tmpl-123');
+                assert.isTrue(client.calledWith('POST', 'WhatsApp/Template/waba-123/tmpl-123/', params));
+            });
+        });
+    });
+
+    describe('get', function () {
+        it('should reject if waba_id is missing', function () {
+            const result = whatsappTemplates.get('', 'tmpl-123');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should reject if template_id is missing', function () {
+            const result = whatsappTemplates.get('waba-123', '');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should call GET with correct path', function () {
+            client.returns(Promise.resolve({
+                body: {
+                    apiId: 'test-api-id',
+                    templateId: 'tmpl-123',
+                    name: 'sample_template',
+                    category: 'MARKETING',
+                    language: 'en_US',
+                    status: 'APPROVED',
+                    components: [],
+                    qualityScore: {},
+                    rejectedReason: null,
+                    message: 'success'
+                }
+            }));
+
+            return whatsappTemplates.get('waba-123', 'tmpl-123').then(function (response) {
+                assert.instanceOf(response, WhatsAppTemplateGetResponse);
+                assert.equal(response.templateId, 'tmpl-123');
+                assert.equal(response.name, 'sample_template');
+                assert.isTrue(client.calledWith('GET', 'WhatsApp/Template/waba-123/tmpl-123/'));
+            });
+        });
+    });
+
+    describe('list', function () {
+        it('should reject if waba_id is missing', function () {
+            const result = whatsappTemplates.list('');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should call GET with correct path and params', function () {
+            client.returns(Promise.resolve({
+                body: {
+                    apiId: 'test-api-id',
+                    objects: [],
+                    meta: { limit: 20, offset: 0, totalCount: 0 },
+                    status: 'success',
+                    message: 'Listed'
+                }
+            }));
+
+            const params = { template_name: 'sample', limit: 20, offset: 0 };
+
+            return whatsappTemplates.list('waba-123', params).then(function (response) {
+                assert.instanceOf(response, WhatsAppTemplateListResponse);
+                assert.isArray(response.objects);
+                assert.isTrue(client.calledWith('GET', 'WhatsApp/Template/waba-123/', params));
+            });
+        });
+    });
+
+    describe('delete', function () {
+        it('should reject if waba_id is missing', function () {
+            const result = whatsappTemplates.delete('', 'tmpl-123', 'sample_template');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should reject if template_id is missing', function () {
+            const result = whatsappTemplates.delete('waba-123', '', 'sample_template');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should reject if name is missing', function () {
+            const result = whatsappTemplates.delete('waba-123', 'tmpl-123', '');
+            return result.then(
+                () => { assert.fail('Expected error'); },
+                (err) => { assert.ok(err); }
+            );
+        });
+
+        it('should call DELETE with correct path and name', function () {
+            client.returns(Promise.resolve({}));
+
+            return whatsappTemplates.delete('waba-123', 'tmpl-123', 'sample_template').then(function (response) {
+                assert.isTrue(response);
+                assert.isTrue(client.calledWith('DELETE', 'WhatsApp/Template/waba-123/tmpl-123/', {
+                    name: 'sample_template'
+                }));
+            });
+        });
+    });
+});

--- a/tests/verify_session_test.js
+++ b/tests/verify_session_test.js
@@ -1,0 +1,76 @@
+import {
+    VerifySessionInterface,
+    CreateVerifySessionResponse
+} from '../lib/resources/verify_session.js';
+import assert from 'assert';
+
+describe('VerifySession', () => {
+    describe('create', () => {
+        it('should create a verify session with optional params', done => {
+            const mockBody = {
+                apiId: 'api-id-123',
+                sessionUuid: 'session-uuid-456',
+                message: 'Session initiated'
+            };
+
+            const mockClient = (method, url, params) => {
+                return new Promise((resolve) => {
+                    assert.equal(method, 'POST');
+                    assert.equal(url, 'Verify/Session/');
+                    resolve({ body: mockBody });
+                });
+            };
+
+            const verifySessionInterface = new VerifySessionInterface(mockClient);
+
+            verifySessionInterface.create({
+                brand_name: 'MyBrand',
+                app_hash: 'abc123hash',
+                code_length: 6,
+                text: 'Your OTP is <otp>',
+                fraud_check: 'standard',
+                dlt_entity_id: 'dlt_entity_id',
+                dlt_template_id: 'dlt_template_id',
+                dlt_template_category: 'dlt_template_category',
+                dlt_sender_id: 'dlt_sender_id',
+                dlt_text: 'Your OTP is <otp>',
+                dtmf: 1
+            })
+                .then(response => {
+                    assert.ok(response instanceof CreateVerifySessionResponse);
+                    assert.equal(response.apiId, 'api-id-123');
+                    assert.equal(response.sessionUuid, 'session-uuid-456');
+                    assert.equal(response.message, 'Session initiated');
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should create a verify session with no params', done => {
+            const mockBody = {
+                apiId: 'api-id-789',
+                sessionUuid: 'session-uuid-101',
+                message: 'Session initiated'
+            };
+
+            const mockClient = (method, url, params) => {
+                return new Promise((resolve) => {
+                    assert.equal(method, 'POST');
+                    assert.equal(url, 'Verify/Session/');
+                    resolve({ body: mockBody });
+                });
+            };
+
+            const verifySessionInterface = new VerifySessionInterface(mockClient);
+
+            verifySessionInterface.create()
+                .then(response => {
+                    assert.ok(response instanceof CreateVerifySessionResponse);
+                    assert.equal(response.apiId, 'api-id-789');
+                    assert.equal(response.sessionUuid, 'session-uuid-101');
+                    done();
+                })
+                .catch(done);
+        });
+    });
+});


### PR DESCRIPTION
# Add whatsapp_templates.create, whatsapp_templates.update, whatsapp_templates.get, whatsapp_templates.list, whatsapp_templates.delete, verify_apps.create, verify_apps.list, verify_apps.list_templates, verify_apps.get, verify_apps.update, verify_apps.delete, rcs_capability.check, rcs_assistant_events.create, verify_session.create, messages.create, messages.list, messages.get, verify_apps.create

Base: master ← rune/pr-630-sdk-updates

Reviewers (picked by recent commit activity):
- @avinashp-plivo (4 commits)
- Koushik SK <koushik.sk@ip-192-168-29-186.ap-south-1.compute.internal> (3 commits)

Adds the following methods:

- `whatsapp_templates.create()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/` — Create a WhatsApp message template under the given WABA.
- `whatsapp_templates.update()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Update an existing WhatsApp message template.
- `whatsapp_templates.get()` — `GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Retrieve a WhatsApp template by its ID.
- `whatsapp_templates.list()` — `GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/` — List WhatsApp templates for the given WABA with optional name filter and pagination.
- `whatsapp_templates.delete()` — `DELETE /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Delete a WhatsApp template by ID and name.
- `verify_apps.create()` — `POST /v1/Account/{auth_id}/Verify/App/` — Create a Verify application for the account.
- `verify_apps.list()` — `GET /v1/Account/{auth_id}/Verify/App/` — List Verify applications for an account with optional filters.
- `verify_apps.list_templates()` — `GET /v1/Account/{auth_id}/Verify/App/templates/` — List default Verify templates available to the account.
- `verify_apps.get()` — `GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Retrieve a Verify application by its UUID.
- `verify_apps.update()` — `POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Update a Verify application (partial update — request body must include at least one field).
- `verify_apps.delete()` — `DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Delete a Verify application.
- `rcs_capability.check()` — `GET /v1/Account/{auth_id}/RCS/Capability/` — Check if a phone number is RCS-enabled.
- `rcs_assistant_events.create()` — `POST /v1/Account/{auth_id}/RCS/AssistantEvents/` — Send RCS assistant events.
- `verify_session.create()` — `POST /v1/Account/{auth_id}/Verify/Session/` — Handle user session for generating OTP based on the request.
- `messages.create()` — `POST /v1/Account/{auth_id}/Message/` — Add content_message field for RCS rich content to the send message request.
- `messages.list()` — `GET /v1/Account/{auth_id}/Message/` — Add error_message, message_sent_time, and message_updated_time fields to the list messages response.
- `messages.get()` — `GET /v1/Account/{auth_id}/Message/{record_id}/` — Add error_message, message_sent_time, and message_updated_time fields to the get message response.
- `verify_apps.create()` — `POST /v1/Account/{auth_id}/Verify/App/` — Add number_pool field to the Verify app create request.

Each method ships with a unit test, a usage example, a bumped version, and a CHANGELOG entry.
