### PR TITLE
feat: add Doing Business As (DBA) field support to Profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [v4.78.0](https://github.com/plivo/plivo-node/tree/v4.78.0) (2026-05-25)
+**Feature - Profile API DBA field support**
+- Added Doing Business As (DBA) field support to Profile API
+
 ## [v4.77.0](https://github.com/plivo/plivo-node/tree/v4.77.0) (2026-05-05)
 **Feature - Account Phone Number typed param surface + bug fixes**
 - Extended `numbers.update()` typed surface to cover all documented params: `complianceApplicationId`, `cnam`, `cnamCallbackUrl`, `cnamCallbackMethod`, `callerReputation`, `profileUuid`, `callerReputationCallbackUrl`, `callerReputationCallbackMethod` (in addition to existing `appId`, `subAccount`, `alias`, `cnamLookup`)

--- a/lib/resources/profile.js
+++ b/lib/resources/profile.js
@@ -114,10 +114,10 @@ export class ProfileResponse {
      * @param {object} address
      * @param {object} authorized_contact
      * @param {string} business_contact_email
-     * @param {string} dba - Doing Business As (customer-facing name, optional)
+     * @param {string} doing_business_as - Doing Business As (customer-facing name, optional)
      * @return profileResponse response output
      */
-    create(profile_alias,plivo_subaccount,customer_type,entity_type, company_name,ein,vertical,ein_issuing_country,stock_symbol,stock_exchange, alt_business_id_type, website, address, authorized_contact, business_contact_email, dba){
+    create(profile_alias,plivo_subaccount,customer_type,entity_type, company_name,ein,vertical,ein_issuing_country,stock_symbol,stock_exchange, alt_business_id_type, website, address, authorized_contact, business_contact_email, doing_business_as){
         let params = {}
         params.profile_alias=profile_alias;
         params.plivo_subaccount=plivo_subaccount;
@@ -134,7 +134,7 @@ export class ProfileResponse {
         params.address=address;
         params.authorized_contact=authorized_contact;
         params.business_contact_email=business_contact_email;
-        params.doing_business_as=dba;
+        params.doing_business_as=doing_business_as;
         let client = this[clientKey];
         return new Promise((resolve, reject) => {
             client('POST', action, params)

--- a/lib/resources/profile.js
+++ b/lib/resources/profile.js
@@ -134,7 +134,7 @@ export class ProfileResponse {
         params.address=address;
         params.authorized_contact=authorized_contact;
         params.business_contact_email=business_contact_email;
-        params.dba=dba;
+        params.doing_business_as=dba;
         let client = this[clientKey];
         return new Promise((resolve, reject) => {
             client('POST', action, params)
@@ -159,7 +159,7 @@ export class ProfileResponse {
      *   @param {string} [params.company_name] - company_name
      *   @param {string} [params.website] - website
      *   @param {string} [params.business_contact_email] - business_contact_email
-     *   @param {string} [params.dba] - Doing Business As (customer-facing name, optional)
+     *   @param {string} [params.doing_business_as] - Doing Business As (customer-facing name, optional)
      * @return profileResponse response output
      */
     update(profile_uuid, params){

--- a/lib/resources/profile.js
+++ b/lib/resources/profile.js
@@ -99,24 +99,25 @@ export class ProfileResponse {
     /**
      * Create a new Profile
      *
-     * @param {string} profile_alias 
-     * @param {string} plivo_subaccount 
-     * @param {string} customer_type 
-     * @param {string} entity_type 
-     * @param {string} company_name 
-     * @param {string} ein  
-     * @param {string} vertical 
-     * @param {string} ein_issuing_country 
-     * @param {string} stock_symbol 
-     * @param {string} stock_exchange 
+     * @param {string} profile_alias
+     * @param {string} plivo_subaccount
+     * @param {string} customer_type
+     * @param {string} entity_type
+     * @param {string} company_name
+     * @param {string} ein
+     * @param {string} vertical
+     * @param {string} ein_issuing_country
+     * @param {string} stock_symbol
+     * @param {string} stock_exchange
      * @param {string} alt_business_id_type
-     * @param {string} website 
+     * @param {string} website
      * @param {object} address
      * @param {object} authorized_contact
      * @param {string} business_contact_email
+     * @param {string} dba - Doing Business As (customer-facing name, optional)
      * @return profileResponse response output
      */
-    create(profile_alias,plivo_subaccount,customer_type,entity_type, company_name,ein,vertical,ein_issuing_country,stock_symbol,stock_exchange, alt_business_id_type, website, address, authorized_contact, business_contact_email){
+    create(profile_alias,plivo_subaccount,customer_type,entity_type, company_name,ein,vertical,ein_issuing_country,stock_symbol,stock_exchange, alt_business_id_type, website, address, authorized_contact, business_contact_email, dba){
         let params = {}
         params.profile_alias=profile_alias;
         params.plivo_subaccount=plivo_subaccount;
@@ -133,6 +134,7 @@ export class ProfileResponse {
         params.address=address;
         params.authorized_contact=authorized_contact;
         params.business_contact_email=business_contact_email;
+        params.dba=dba;
         let client = this[clientKey];
         return new Promise((resolve, reject) => {
             client('POST', action, params)
@@ -148,7 +150,7 @@ export class ProfileResponse {
     /**
      * update a new Profile
      *
-     * @param {string} profile_uuid 
+     * @param {string} profile_uuid
      * @param {object} params - params object containing:
      *   @param {object} [params.address] - address object
      *   @param {object} [params.authorized_contact] - authorized_contact object
@@ -157,6 +159,7 @@ export class ProfileResponse {
      *   @param {string} [params.company_name] - company_name
      *   @param {string} [params.website] - website
      *   @param {string} [params.business_contact_email] - business_contact_email
+     *   @param {string} [params.dba] - Doing Business As (customer-facing name, optional)
      * @return profileResponse response output
      */
     update(profile_uuid, params){

--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -1751,6 +1751,7 @@ export function Request(config) {
                 },
                 company_name: "ABC Inc.",
                 customer_type: "RESELLER",
+                dba: "ABC DBA",
                 ein: "111111111",
                 ein_issuing_country: "US",
                 entity_type: "PUBLIC_PROFIT",

--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -1751,7 +1751,7 @@ export function Request(config) {
                 },
                 company_name: "ABC Inc.",
                 customer_type: "RESELLER",
-                dba: "ABC DBA",
+                doing_business_as: "ABC DBA",
                 ein: "111111111",
                 ein_issuing_country: "US",
                 entity_type: "PUBLIC_PROFIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.77.0",
+  "version": "4.78.0",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/test/profile.js
+++ b/test/profile.js
@@ -14,7 +14,7 @@ import {
       return client.profile.get("06ecae31-4bf8-40b9-ac62-e902418e9935")
         .then(function (response) {
           assert.equal(response.profile.profileUuid, "06ecae31-4bf8-40b9-ac62-e902418e9935")
-          assert.equal(response.profile.dba, "ABC DBA")
+          assert.equal(response.profile.doing_business_as, "ABC DBA")
         })
     });
     

--- a/test/profile.js
+++ b/test/profile.js
@@ -14,6 +14,7 @@ import {
       return client.profile.get("06ecae31-4bf8-40b9-ac62-e902418e9935")
         .then(function (response) {
           assert.equal(response.profile.profileUuid, "06ecae31-4bf8-40b9-ac62-e902418e9935")
+          assert.equal(response.profile.dba, "ABC DBA")
         })
     });
     
@@ -62,7 +63,8 @@ import {
         "https://testcompany.com",
         address,
         authorized_contact,
-        business_contact_email
+        business_contact_email,
+        "Test DBA"
       )
         .then(function (profile) {
           assert.equal(profile.profileUuid, '43d0616e-d50a-445a-a84e-310a089f0618')

--- a/types/resources/profile.d.ts
+++ b/types/resources/profile.d.ts
@@ -117,7 +117,7 @@ export class ProfileInterface extends PlivoResource {
             ein_issuing_country?: string;
             alt_business_id?: string;
             alt_business_id_type?: string;
-            dba?: string;
+            doing_business_as?: string;
         }
     ): Promise<ProfileResponse>;
     [clientKey]: symbol;

--- a/types/resources/profile.d.ts
+++ b/types/resources/profile.d.ts
@@ -69,7 +69,7 @@ export class ProfileInterface extends PlivoResource {
      * @param {object} address
      * @param {object} authorized_contact
      * @param {string} business_contact_email
-     * @param {string} dba - Doing Business As (customer-facing name, optional)
+     * @param {string} doing_business_as - Doing Business As (customer-facing name, optional)
      * @return profileResponse response output
      */
     create(
@@ -88,7 +88,7 @@ export class ProfileInterface extends PlivoResource {
         address: object,
         authorized_contact: object,
         business_contact_email?: string,
-        dba?: string
+        doing_business_as?: string
     ): Promise<ProfileResponse>;
 
     /**

--- a/types/resources/profile.d.ts
+++ b/types/resources/profile.d.ts
@@ -69,6 +69,7 @@ export class ProfileInterface extends PlivoResource {
      * @param {object} address
      * @param {object} authorized_contact
      * @param {string} business_contact_email
+     * @param {string} dba - Doing Business As (customer-facing name, optional)
      * @return profileResponse response output
      */
     create(
@@ -86,7 +87,8 @@ export class ProfileInterface extends PlivoResource {
         website: string,
         address: object,
         authorized_contact: object,
-        business_contact_email?: string
+        business_contact_email?: string,
+        dba?: string
     ): Promise<ProfileResponse>;
 
     /**
@@ -115,6 +117,7 @@ export class ProfileInterface extends PlivoResource {
             ein_issuing_country?: string;
             alt_business_id?: string;
             alt_business_id_type?: string;
+            dba?: string;
         }
     ): Promise<ProfileResponse>;
     [clientKey]: symbol;


### PR DESCRIPTION
## Summary
- Added Doing Business As (DBA) field support to Profile API

## Test plan
- [ ] Verify Profile API create/update with `doing_business_as` field
- [ ] Verify Profile API get response includes `doing_business_as` field