### PR TITLE
feat: expose sub_account_name on Number resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-## [v4.77.1](https://github.com/plivo/plivo-node/tree/v4.77.1) (2026-05-25)
+## [v4.77.1](https://github.com/plivo/plivo-node/tree/v4.77.1) (2026-05-26)
 **Feature - Expose sub_account_name on Number resource**
 - `Number` resource now surfaces `sub_account_name` alongside the existing `sub_account` (auth_id) on rented number listing and get APIs (dynamic property, already worked at runtime; this release adds explicit test coverage)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [v4.77.1](https://github.com/plivo/plivo-node/tree/v4.77.1) (2026-05-25)
+**Feature - Expose sub_account_name on Number resource**
+- `Number` resource now surfaces `sub_account_name` alongside the existing `sub_account` (auth_id) on rented number listing and get APIs (dynamic property, already worked at runtime; this release adds explicit test coverage)
+
 ## [v4.77.0](https://github.com/plivo/plivo-node/tree/v4.77.0) (2026-05-05)
 **Feature - Account Phone Number typed param surface + bug fixes**
 - Extended `numbers.update()` typed surface to cover all documented params: `complianceApplicationId`, `cnam`, `cnamCallbackUrl`, `cnamCallbackMethod`, `callerReputation`, `profileUuid`, `callerReputationCallbackUrl`, `callerReputationCallbackMethod` (in addition to existing `appId`, `subAccount`, `alias`, `cnamLookup`)

--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -1366,7 +1366,8 @@ export function Request(config) {
             resource_uri: '/v1/Account/MANWVLYTK4ZWU1YTY4ZT/Number/17609915566/',
             sms_enabled: true,
             sms_rate: '0.00000',
-            sub_account: null,
+            sub_account: 'SAXXXXXXXXXXXXXXXXXX',
+            sub_account_name: 'Marketing',
             voice_enabled: true,
             voice_rate: '0.00850'
           }
@@ -1397,7 +1398,8 @@ export function Request(config) {
               resource_uri: '/v1/Account/MANWVLYTK4ZWU1YTY4ZT/Number/18135401302/',
               sms_enabled: true,
               sms_rate: '0.00000',
-              sub_account: null,
+              sub_account: 'SAXXXXXXXXXXXXXXXXXX',
+              sub_account_name: 'Marketing',
               voice_enabled: true,
               voice_rate: '0.00850'
             }]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.77.0",
+  "version": "4.77.1",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/test/numbers.js
+++ b/test/numbers.js
@@ -10,6 +10,8 @@ describe('NumberInterface', function () {
     return client.numbers.get('+919999999990')
       .then(function(number) {
         assert.equal(number.id, '+919999999990')
+        assert.equal(number.subAccount, 'SAXXXXXXXXXXXXXXXXXX')
+        assert.equal(number.subAccountName, 'Marketing')
       })
   });
 
@@ -17,6 +19,8 @@ describe('NumberInterface', function () {
     return client.numbers.list()
       .then(function(numbers) {
         assert.equal(numbers.length, 1)
+        assert.equal(numbers[0].subAccount, 'SAXXXXXXXXXXXXXXXXXX')
+        assert.equal(numbers[0].subAccountName, 'Marketing')
       })
   });
 


### PR DESCRIPTION
## Summary
- Adds explicit test coverage that `number.subAccount` and `number.subAccountName` are surfaced by the SDK on rented number `get()` and `list()` APIs.
- The fields already flow through at runtime via the SDK's response handler (snake_case → camelCase auto-conversion); this release makes the behavior part of the contract.
- Bumped version 4.77.0 → 4.77.1.

Mirrors the parallel FNT-370 work in plivo-go#244, plivo-ruby#264, plivo-java#317, plivo-php#371, plivo-dotnet#312, plivo-python#312.

## Test plan
- [x] `npx mocha --require babel-register test/numbers.js` passes locally (14/14)
- [x] Full Node test suite passes (281/281)
- [x] Updated mock body in `lib/rest/request-test.js` to include `sub_account` + `sub_account_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)