### PR TITLE
feat: add number_of_employees field to Profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [v4.77.2](https://github.com/plivo/plivo-node/tree/v4.77.2) (2026-06-10)
+**Feature - Profile API number of employees field support**
+- Added Number of Employees field support to Profile API
+
 ## [v4.77.1](https://github.com/plivo/plivo-node/tree/v4.77.1) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/lib/resources/profile.js
+++ b/lib/resources/profile.js
@@ -115,9 +115,10 @@ export class ProfileResponse {
      * @param {object} authorized_contact
      * @param {string} business_contact_email
      * @param {string} doing_business_as - Doing Business As (customer-facing name, optional)
+     * @param {string} number_of_employees - Number of Employees (optional). Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500, BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
      * @return profileResponse response output
      */
-    create(profile_alias,plivo_subaccount,customer_type,entity_type, company_name,ein,vertical,ein_issuing_country,stock_symbol,stock_exchange, alt_business_id_type, website, address, authorized_contact, business_contact_email, doing_business_as){
+    create(profile_alias,plivo_subaccount,customer_type,entity_type, company_name,ein,vertical,ein_issuing_country,stock_symbol,stock_exchange, alt_business_id_type, website, address, authorized_contact, business_contact_email, doing_business_as, number_of_employees){
         let params = {}
         params.profile_alias=profile_alias;
         params.plivo_subaccount=plivo_subaccount;
@@ -135,6 +136,7 @@ export class ProfileResponse {
         params.authorized_contact=authorized_contact;
         params.business_contact_email=business_contact_email;
         params.doing_business_as=doing_business_as;
+        params.number_of_employees=number_of_employees;
         let client = this[clientKey];
         return new Promise((resolve, reject) => {
             client('POST', action, params)
@@ -160,6 +162,7 @@ export class ProfileResponse {
      *   @param {string} [params.website] - website
      *   @param {string} [params.business_contact_email] - business_contact_email
      *   @param {string} [params.doing_business_as] - Doing Business As (customer-facing name, optional)
+     *   @param {string} [params.number_of_employees] - Number of Employees (optional). Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500, BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
      * @return profileResponse response output
      */
     update(profile_uuid, params){

--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -1754,6 +1754,7 @@ export function Request(config) {
                 company_name: "ABC Inc.",
                 customer_type: "RESELLER",
                 doing_business_as: "ABC DBA",
+                number_of_employees: "BETWEEN_11_AND_50",
                 ein: "111111111",
                 ein_issuing_country: "US",
                 entity_type: "PUBLIC_PROFIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.77.1",
+  "version": "4.77.2",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/test/profile.js
+++ b/test/profile.js
@@ -15,6 +15,7 @@ import {
         .then(function (response) {
           assert.equal(response.profile.profileUuid, "06ecae31-4bf8-40b9-ac62-e902418e9935")
           assert.equal(response.profile.doing_business_as, "ABC DBA")
+          assert.equal(response.profile.number_of_employees, "BETWEEN_11_AND_50")
         })
     });
     
@@ -64,7 +65,8 @@ import {
         address,
         authorized_contact,
         business_contact_email,
-        "Test DBA"
+        "Test DBA",
+        "BETWEEN_11_AND_50"
       )
         .then(function (profile) {
           assert.equal(profile.profileUuid, '43d0616e-d50a-445a-a84e-310a089f0618')

--- a/types/resources/profile.d.ts
+++ b/types/resources/profile.d.ts
@@ -70,6 +70,7 @@ export class ProfileInterface extends PlivoResource {
      * @param {object} authorized_contact
      * @param {string} business_contact_email
      * @param {string} doing_business_as - Doing Business As (customer-facing name, optional)
+     * @param {string} number_of_employees - Number of Employees (optional). Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500, BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
      * @return profileResponse response output
      */
     create(
@@ -88,7 +89,8 @@ export class ProfileInterface extends PlivoResource {
         address: object,
         authorized_contact: object,
         business_contact_email?: string,
-        doing_business_as?: string
+        doing_business_as?: string,
+        number_of_employees?: string
     ): Promise<ProfileResponse>;
 
     /**
@@ -118,6 +120,7 @@ export class ProfileInterface extends PlivoResource {
             alt_business_id?: string;
             alt_business_id_type?: string;
             doing_business_as?: string;
+            number_of_employees?: string;
         }
     ): Promise<ProfileResponse>;
     [clientKey]: symbol;


### PR DESCRIPTION
## Summary
Adds a new optional `number_of_employees` string field to the Profile (10DLC/A2P account profile) create and update APIs. This mirrors a backend change in campaign-service where `number_of_employees` was added to the Profile create & update request as an optional string.

The field is implemented exactly like the recently-added `doing_business_as` (DBA) field — same files, positions (right after DBA), and style.

## Details
- No client-side enum validation; the server validates the value.
- The 7 allowed values are documented (not enforced) in JSDoc and `.d.ts` comments: `BETWEEN_1_AND_10`, `BETWEEN_11_AND_50`, `BETWEEN_51_AND_200`, `BETWEEN_201_AND_500`, `BETWEEN_501_AND_2000`, `BETWEEN_2001_AND_10000`, `MORE_THAN_10001`.

## Changes
- `lib/resources/profile.js` — added `number_of_employees` create param + JSDoc (create & update).
- `types/resources/profile.d.ts` — added optional `number_of_employees` to create signature and update params type.
- `test/profile.js` — assertion on get-profile fixture + positional arg in create test.
- `lib/rest/request-test.js` — added `number_of_employees` to the GET profile fixture.
- `package.json` — version bump `4.77.1` -> `4.77.2`.
- `CHANGELOG.md` — new top entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)