### PR TITLE
feat: add complianceApplicationId param to numbers.buy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change Log
+## [v4.78.0](https://github.com/plivo/plivo-node/tree/v4.78.0) (2026-06-11)
+**Feature - complianceApplicationId support on numbers.buy()**
+- Added optional `complianceApplicationId` parameter to `numbers.buy(number, appId, cnamLookup, haEnable, complianceApplicationId)`, serialized to the `compliance_application_id` wire param. This lets regulated numbers (e.g. India) be purchased with an approved regulatory compliance application linked at purchase time, instead of only via `numbers.update()` after renting.
+- TypeScript declarations updated to mirror the new optional param across `PhoneNumber.buy`, `PhoneNumberInterface.buy`, and `NumberInterface.buy`.
+- Added unit test asserting `compliance_application_id` is forwarded on the buy request. Change is backward-compatible (trailing optional positional param).
+
 ## [v4.77.1](https://github.com/plivo/plivo-node/tree/v4.77.1) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/lib/resources/numbers.js
+++ b/lib/resources/numbers.js
@@ -83,13 +83,14 @@ export class PhoneNumber extends PlivoResource {
      * @param {string} appId - app id
      * @param {string} cnamLookup - cnam lookup
      * @param {boolean} haEnable - enable HA Number
+     * @param {string} complianceApplicationId - approved regulatory compliance application id to link to the number at purchase (required for regulated numbers such as India)
      * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
      * @fail {Error} return Error
      */
-    buy(number, appId, cnamLookup, haEnable) {
+    buy(number, appId, cnamLookup, haEnable, complianceApplicationId) {
         return new PhoneNumberInterface(this[clientKey], {
             id: this.id
-        }).buy(number, appId, cnamLookup, haEnable);
+        }).buy(number, appId, cnamLookup, haEnable, complianceApplicationId);
     }
 }
 
@@ -114,10 +115,11 @@ export class PhoneNumberInterface extends PlivoResourceInterface {
      * @param {string} appId - app id
      * @param {string} cnamLookup - cnam lookup
      * @param {boolean} haEnable - enable HA Number
+     * @param {string} complianceApplicationId - approved regulatory compliance application id to link to the number at purchase (required for regulated numbers such as India)
      * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
      * @fail {Error} return Error
      */
-    buy(number, appId, cnamLookup, haEnable) {
+    buy(number, appId, cnamLookup, haEnable, complianceApplicationId) {
         let params = {};
         if (appId) {
             params.app_id = appId;
@@ -127,6 +129,9 @@ export class PhoneNumberInterface extends PlivoResourceInterface {
         }
         if (haEnable !== undefined) {
             params.ha_enable = haEnable;
+        }
+        if (complianceApplicationId) {
+            params.compliance_application_id = complianceApplicationId;
         }
         let client = this[clientKey];
 
@@ -249,10 +254,11 @@ export class NumberInterface extends PlivoResourceInterface {
      * @param {string} appId - app id
      * @param {string} cnamLookup - cnam lookup
      * @param {boolean} haEnable - enable HA Number
+     * @param {string} complianceApplicationId - approved regulatory compliance application id to link to the number at purchase (required for regulated numbers such as India)
      * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
      * @fail {Error} return Error
      */
-    buy(number, appId, cnamLookup, haEnable) {
+    buy(number, appId, cnamLookup, haEnable, complianceApplicationId) {
         let errors = validate([{
             field: 'number',
             value: number,
@@ -264,7 +270,7 @@ export class NumberInterface extends PlivoResourceInterface {
         }
         return new PhoneNumber(this[clientKey], {
             id: number
-        }).buy(number, appId, cnamLookup, haEnable);
+        }).buy(number, appId, cnamLookup, haEnable, complianceApplicationId);
     }
 
     /**

--- a/lib/rest/request-test.js
+++ b/lib/rest/request-test.js
@@ -1488,6 +1488,23 @@ export function Request(config) {
         });
       }
 
+      else if (method == 'POST' && action == 'PhoneNumber/+919999999990/' && params.compliance_application_id === 'comp-app-uuid') {
+        resolve({
+          response: {},
+          body: {
+            api_id: 'aa52882c-1c88-11e4-bd8a-12313f016a39',
+            message: 'compliance-applied',
+            numbers: [
+              {
+                number: '14154009186',
+                status: 'Success'
+              }
+            ],
+            status: 'fulfilled'
+          }
+        });
+      }
+
       else if (method == 'POST' && action == 'PhoneNumber/+919999999990/') {
         resolve({
           response: {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plivo",
-  "version": "4.77.1",
+  "version": "4.78.0",
   "description": "A Node.js SDK to make voice calls and send SMS using Plivo and to generate Plivo XML",
   "homepage": "https://github.com/plivo/plivo-node",
   "files": [

--- a/test/numbers.js
+++ b/test/numbers.js
@@ -132,6 +132,15 @@ describe('NumberInterface', function () {
       })
   });
 
+  it('Buy Number with complianceApplicationId', function () {
+    return client.numbers.buy('+919999999990', 'appId', undefined, undefined, 'comp-app-uuid')
+      .then(function(numbers) {
+        assert.equal(numbers.status, 'fulfilled')
+        // distinguishable mock branch only matches when compliance_application_id is forwarded on the wire
+        assert.equal(numbers.message, 'compliance-applied')
+      })
+  });
+
   it('should throw error for number in buy', function () {
     return client.numbers.buy()
       .catch(function(err) {

--- a/types/resources/numbers.d.ts
+++ b/types/resources/numbers.d.ts
@@ -48,10 +48,11 @@ export class PhoneNumber extends PlivoResource {
 	 * @param {string} appId - app id
 	 * @param {string} cnamLookup - cnam lookup
 	 * @param {boolean} haEnable - enable HA Number
+	 * @param {string} complianceApplicationId - approved regulatory compliance application id to link at purchase (required for regulated numbers such as India)
 	 * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
 	 * @fail {Error} return Error
 	 */
-	buy(number: string, appId?: string, cnamLookup?: string, haEnable?: boolean): Promise<any>;
+	buy(number: string, appId?: string, cnamLookup?: string, haEnable?: boolean, complianceApplicationId?: string): Promise<any>;
 	[clientKey]: symbol;
 }
 /**
@@ -69,10 +70,11 @@ export class PhoneNumberInterface extends PlivoResourceInterface {
 	 * @param {string} appId - app id
 	 * @param {string} cnamLookup - cnam lookup
 	 * @param {boolean} haEnable - enable HA Number
+	 * @param {string} complianceApplicationId - approved regulatory compliance application id to link at purchase (required for regulated numbers such as India)
 	 * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
 	 * @fail {Error} return Error
 	 */
-	buy(number: string, appId?: string, cnamLookup?: string, haEnable?: boolean): Promise<any>;
+	buy(number: string, appId?: string, cnamLookup?: string, haEnable?: boolean, complianceApplicationId?: string): Promise<any>;
 	[clientKey]: symbol;
 }
 /**
@@ -108,10 +110,11 @@ export class NumberInterface extends PlivoResourceInterface {
 	 * @param {string} appId - app id
 	 * @param {string} cnamLookup - cnam lookup
 	 * @param {boolean} haEnable - enable HA Number
+	 * @param {string} complianceApplicationId - approved regulatory compliance application id to link at purchase (required for regulated numbers such as India)
 	 * @promise {@link PlivoGenericResponse} return PlivoGenericResponse Object if success
 	 * @fail {Error} return Error
 	 */
-	buy(number: string, appId?: string, cnamLookup?: string, haEnable?: boolean): Promise<BuyNumberResponse>;
+	buy(number: string, appId?: string, cnamLookup?: string, haEnable?: boolean, complianceApplicationId?: string): Promise<BuyNumberResponse>;
 	/**
 	 * Add own number from carrier
 	 * @method


### PR DESCRIPTION
## What

Adds an optional 5th positional parameter **`complianceApplicationId`** to the phone-number `buy()` method:

```js
numbers.buy(number, appId, cnamLookup, haEnable, complianceApplicationId)
```

It is serialized to the `compliance_application_id` wire param on the `POST /PhoneNumber/{number}/` request.

## Why

Regulated numbers (e.g. **India**) require an approved regulatory compliance application to be linked **at purchase time**. The number service rent endpoint accepts `compliance_application_id` in the body, but the SDK's `buy()` previously exposed only `appId`, `cnamLookup`, and `haEnable`. The only SDK path to attach a compliance app was `numbers.update()` *after* renting — which doesn't help when the link is needed at purchase. This closes that gap.

## Changes

- Threaded the new optional param through `PhoneNumber.buy`, `PhoneNumberInterface.buy`, and `NumberInterface.buy` (`lib/resources/numbers.js`).
- Mirrored across all three TypeScript signatures (`types/resources/numbers.d.ts`).
- Added a unit test that asserts `compliance_application_id` is actually forwarded on the wire (distinguishable mock branch in `request-test.js`).
- Version bump `4.77.1` → `4.78.0` + CHANGELOG entry.

## Compatibility

Backward-compatible — trailing optional positional parameter; existing callers are unaffected. Matches the positional style used by the other Plivo SDKs.

## Testing

- `npx gulp` → new `Buy Number with complianceApplicationId` test passes; full suite green for numbers.
- Verified end-to-end against the **real prod API** (wire-level): the SDK sends `{compliance_application_id: "…"}` to `https://api.plivo.com/v1/Account/…/PhoneNumber/{number}/` with correct snake_case and no camelCase leak.

> Note: the pre-existing `profile should get profile` test failure exists on `master` independently of this change (DBA release) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)